### PR TITLE
Transpile before building - Closes #33

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -167,6 +167,8 @@ src/node-v$(NODEJS_VERSION)_SHASUMS256.txt.sig:
 	$(DOWNLOAD) https://nodejs.org/dist/v$(NODEJS_VERSION)/SHASUMS256.txt.sig --output-document=$@
 
 ../lisk-core-$(LISK_VERSION).tgz: ../npm-shrinkwrap.json src/node-v$(NODEJS_VERSION)-$(NODEJS_ARCH)
+	cd ../ && PATH="${PWD}/src/node-v$(NODEJS_VERSION)-$(NODEJS_ARCH)/bin:${PATH}" npm ci
+	cd ../ && PATH="${PWD}/src/node-v$(NODEJS_VERSION)-$(NODEJS_ARCH)/bin:${PATH}" npm run build
 	cd ../ && PATH="${PWD}/src/node-v$(NODEJS_VERSION)-$(NODEJS_ARCH)/bin:${PATH}" npm pack
 
 src/lisk-core-$(LISK_VERSION).tgz: ../lisk-core-$(LISK_VERSION).tgz


### PR DESCRIPTION
### What was the problem?

Build were not functional, see #33 

### How did I fix it?

The build process now runs `npm ci` and then `npm run build` before running `npm pack`

### How to test it?

```
cd build/
make LISK_NETWORK=testnet
```

Then try starting the application using `build/release/lisk*.tar.gz`.

### Review checklist

* The PR resolves #33 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
