### PR TITLE
Memory tunning for postgresql on helm chart - Closes #39

### DIFF
--- a/helm/lisk-core/Chart.yaml
+++ b/helm/lisk-core/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.6.0"
 description: Install lisk-core
 name: lisk-core
-version: 0.2.0
+version: 0.3.0

--- a/helm/lisk-core/templates/lisk-core-statefulset.yaml
+++ b/helm/lisk-core/templates/lisk-core-statefulset.yaml
@@ -16,6 +16,9 @@ spec:
     - metadata:
         name: data
       spec:
+        {{- if .Values.postgresql.persistence.storageClassName }}
+        storageClassName: {{ .Values.postgresql.persistence.storageClassName }}
+        {{- end }}
         accessModes: ["ReadWriteOnce"]
         resources:
           requests:
@@ -104,6 +107,32 @@ spec:
         - name: database
           image: {{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}
           imagePullPolicy: {{ .Values.postgresql.image.pullPolicy }}
+          {{- $pgConfig := .Values.postgresql.config }}
+          {{- $pgMaxmemoryKb := .Values.postgresql.resources.limits.memory| regexFind "[0-9]*" | atoi | mul 1024}}
+          {{- $pgSharedBuffers := div $pgMaxmemoryKb 4 }}
+          args:
+            - "-c"
+            - "max_connections={{ $pgConfig.max_connections }}"
+            - "-c"
+            - "shared_buffers={{ $pgSharedBuffers }}kB"
+            - "-c"
+            - "work_mem={{ (mul $pgConfig.max_connections 3)|div (sub $pgMaxmemoryKb $pgSharedBuffers) }}kB"
+            - "-c"
+            - "maintenance_work_mem={{ div $pgMaxmemoryKb 16 }}kB"
+            - "-c"
+            - "effective_cache_size={{ $pgSharedBuffers }}kB"
+            - "-c"
+            - "synchronous_commit=off"
+            - "-c"
+            - "wal_buffers=16MB"
+            - "-c"
+            - "max_wal_size=2GB"
+            - "-c"
+            - "min_wal_size=1GB"
+            - "-c"
+            - "checkpoint_completion_target=0.9"
+            - "-c"
+            - "default_statistics_target=100"
           resources:
 {{ toYaml .Values.postgresql.resources | indent 12 }}
           volumeMounts:

--- a/helm/lisk-core/values.yaml
+++ b/helm/lisk-core/values.yaml
@@ -43,8 +43,11 @@ postgresql:
     repository: postgres
     tag: 10-alpine
     pullPolicy: IfNotPresent
+  config:
+    max_connections: 200
   resources:
     requests:
+      # Memory should be specified in Mi for postgresql tunables work.
       memory: "512Mi"
       cpu: "500m"
     limits:


### PR DESCRIPTION
### What was the problem?
Postgres container on Kubernetes was not properly tuned for lisk core, and suffering for perfomance issues.

### How did I fix it?
Added some tunables on helm chart, following the same pattern as in https://github.com/LiskHQ/lisk-core/blob/master/build/target/tune.sh
### How to test it?
Deploy the chart on a kubernetes cluster, then issue some heavy queries and check resource usage on the pods.
### Review checklist

* The PR resolves #39 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
