### PR TITLE
Fix git command not to console error - Closes #42

### DIFF
--- a/src/helpers/config.ts
+++ b/src/helpers/config.ts
@@ -12,16 +12,14 @@ let buildVersion; // tslint:disable-line no-let
 try {
 	lastCommitId = getLastCommitId();
 } catch (err) {
-	// tslint:disable-next-line no-console
-	console.error('Cannot get last git commit:', err.message);
+	// suppress error
 }
 
 // Try to get the build version
 try {
 	buildVersion = getBuildVersion();
 } catch (err) {
-	// tslint:disable-next-line no-console
-	console.error('Cannot get build version:', err.message);
+	// suppress error
 }
 
 const appSchema = {

--- a/src/helpers/git.ts
+++ b/src/helpers/git.ts
@@ -18,20 +18,14 @@ import childProcess from 'child_process';
 import fs from 'fs';
 
 const getLastCommitIdFromGit = (): string => {
-	// tslint:disable-next-line no-let
-	let lastCommitId = '';
-	try {
-		// .toString() converts Buffer to String, .trim() removes eol character
-		const spawn = childProcess
-			.spawnSync('git', ['rev-parse', 'HEAD']);
-			if (!spawn.stderr.toString().trim()) {
-				lastCommitId = spawn.stdout.toString().trim();
-			}
-	} catch (error) {
-		// suppress error
+	const spawn = childProcess
+		.spawnSync('git', ['rev-parse', 'HEAD']);
+
+	if (!spawn.stderr.toString().trim()) {
+		return spawn.stdout.toString().trim();
 	}
 
-	return lastCommitId;
+	return '';
 };
 
 const getLastCommitIdFromRevisionFile = (): string => {

--- a/src/helpers/git.ts
+++ b/src/helpers/git.ts
@@ -22,16 +22,13 @@ const getLastCommitIdFromGit = (): string => {
 	let lastCommitId = '';
 	try {
 		// .toString() converts Buffer to String, .trim() removes eol character
-		lastCommitId = childProcess
-			.execSync('git rev-parse HEAD')
-			.toString()
-			.trim();
+		const spawn = childProcess
+			.spawnSync('git', ['rev-parse', 'HEAD']);
+			if (!spawn.stderr.toString().trim()) {
+				lastCommitId = spawn.stdout.toString().trim();
+			}
 	} catch (error) {
-		// tslint:disable-next-line no-console
-		console.log(
-			'When getting git rev-parse HEAD, following error happened',
-			error.toString()
-		);
+		// suppress error
 	}
 
 	return lastCommitId;


### PR DESCRIPTION
### What was the problem?
Internal git command was consoling error when `.git` folder does not exists, which breaks the generate config format.

### How did I fix it?
Change git command not to console error.

### How to test it?
npm run build then
Run generate_config.js without `.git` folder, and observe it is valid JSON output.

### Review checklist

* The PR resolves #42
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
