### PR TITLE
Add assetDbRead functions 

### DIFF
--- a/src/transactions/5_dapp_transaction.ts
+++ b/src/transactions/5_dapp_transaction.ts
@@ -359,4 +359,22 @@ export class DappTransaction extends BaseTransaction {
 	protected undoAsset(_: StateStore): ReadonlyArray<TransactionError> {
 		return [];
 	}
+
+	// tslint:disable:next-line: prefer-function-over-method no-any
+	protected assetDbRead(raw: any): object | undefined {
+		if (!raw.dapp_name) {
+			return undefined;
+		}
+		const dapp = {
+			name: raw.dapp_name,
+			description: raw.dapp_description,
+			tags: raw.dapp_tags,
+			type: raw.dapp_type,
+			link: raw.dapp_link,
+			category: raw.dapp_category,
+			icon: raw.dapp_icon,
+		};
+
+		return { dapp };
+	}
 }

--- a/src/transactions/5_dapp_transaction.ts
+++ b/src/transactions/5_dapp_transaction.ts
@@ -361,7 +361,7 @@ export class DappTransaction extends BaseTransaction {
 	}
 
 	// tslint:disable:next-line: prefer-function-over-method no-any
-	protected assetDbRead(raw: any): object | undefined {
+	protected assetFromSync(raw: any): object | undefined {
 		if (!raw.dapp_name) {
 			return undefined;
 		}

--- a/src/transactions/6_in_transfer_transaction.ts
+++ b/src/transactions/6_in_transfer_transaction.ts
@@ -263,7 +263,7 @@ export class InTransferTransaction extends BaseTransaction {
 	}
 
 	// tslint:disable:next-line: prefer-function-over-method no-any
-	protected assetDbRead(raw: any): object | undefined {
+	protected assetFromSync(raw: any): object | undefined {
 		if (!raw.in_dappId) {
 			return undefined;
 		}

--- a/src/transactions/6_in_transfer_transaction.ts
+++ b/src/transactions/6_in_transfer_transaction.ts
@@ -261,4 +261,16 @@ export class InTransferTransaction extends BaseTransaction {
 
 		return errors;
 	}
+
+	// tslint:disable:next-line: prefer-function-over-method no-any
+	protected assetDbRead(raw: any): object | undefined {
+		if (!raw.in_dappId) {
+			return undefined;
+		}
+		const inTransfer = {
+			dappId: raw.in_dappId,
+		};
+	
+		return { inTransfer };
+	}
 }

--- a/src/transactions/7_out_transfer_transaction.ts
+++ b/src/transactions/7_out_transfer_transaction.ts
@@ -279,4 +279,17 @@ export class OutTransferTransaction extends BaseTransaction {
 
 		return errors;
 	}
+
+	// tslint:disable:next-line: prefer-function-over-method no-any
+	protected assetDbRead(raw: any): object | undefined {
+		if (!raw.ot_dappId) {
+			return undefined;
+		}
+		const outTransfer = {
+			dappId: raw.ot_dappId,
+			transactionId: raw.ot_outTransactionId,
+		};
+	
+		return { outTransfer };
+	}
 }

--- a/src/transactions/7_out_transfer_transaction.ts
+++ b/src/transactions/7_out_transfer_transaction.ts
@@ -281,7 +281,7 @@ export class OutTransferTransaction extends BaseTransaction {
 	}
 
 	// tslint:disable:next-line: prefer-function-over-method no-any
-	protected assetDbRead(raw: any): object | undefined {
+	protected assetFromSync(raw: any): object | undefined {
 		if (!raw.ot_dappId) {
 			return undefined;
 		}


### PR DESCRIPTION
### What was the problem?

Missing `assetDbRead` functions in type 5, 6 and 7 transactions.

### How did I fix it?

Added functions

### Review checklist

* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
