### PR TITLE
Remove shared.sh from Makefile

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -56,7 +56,6 @@ src/lisk-$(LISK_VERSION)-$(UNAME_S)-x86_64_image/finished: \
 		src/lisk-$(LISK_VERSION)-$(UNAME_S)-x86_64_image/env.sh \
 		src/lisk-$(LISK_VERSION)-$(UNAME_S)-x86_64_image/lisk.sh \
 		src/lisk-$(LISK_VERSION)-$(UNAME_S)-x86_64_image/lisk_snapshot.sh \
-		src/lisk-$(LISK_VERSION)-$(UNAME_S)-x86_64_image/shared.sh \
 		src/lisk-$(LISK_VERSION)-$(UNAME_S)-x86_64_image/tune.sh \
 		src/lisk-$(LISK_VERSION)-$(UNAME_S)-x86_64_image/bin/jq \
 		src/lisk-$(LISK_VERSION)-$(UNAME_S)-x86_64_image/bin/lisk \
@@ -108,8 +107,6 @@ src/lisk-$(LISK_VERSION)-$(UNAME_S)-x86_64_image/config.json: | src/lisk-$(LISK_
 
 src/lisk-$(LISK_VERSION)-$(UNAME_S)-x86_64_image/env.sh: | src/lisk-$(LISK_VERSION)-$(UNAME_S)-x86_64_image
 	( cat target/env.sh; echo "export LISK_NETWORK=$(LISK_NETWORK)" ) |tee $@
-src/lisk-$(LISK_VERSION)-$(UNAME_S)-x86_64_image/shared.sh: | src/lisk-$(LISK_VERSION)-$(UNAME_S)-x86_64_image
-	$(INSTALL) --mode=0644 target/$(@F) $@
 src/lisk-$(LISK_VERSION)-$(UNAME_S)-x86_64_image/%.sh: | src/lisk-$(LISK_VERSION)-$(UNAME_S)-x86_64_image
 	$(INSTALL) --mode=0755 target/$(@F) $@
 src/lisk-$(LISK_VERSION)-$(UNAME_S)-x86_64_image/etc/%: | src/lisk-$(LISK_VERSION)-$(UNAME_S)-x86_64_image/etc


### PR DESCRIPTION
### What was the problem?

`shared.sh` was still referenced in `build/Makefile` although it was removed in https://github.com/LiskHQ/lisk-core/pull/46.

### How did I fix it?

Removed references to `shared.sh` from `build/Makefile`.

### How to test it?

```
cd build/
make LISK_NETWORK=testnet
``` 

### Review checklist

* The PR resolves #50
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
