### PR TITLE
Rename database config key - Closes #55

### DIFF
--- a/build/target/lisk_snapshot.sh
+++ b/build/target/lisk_snapshot.sh
@@ -39,7 +39,7 @@ cd "$( cd -P -- "$(dirname -- "$0")" && pwd -P )" || exit 2
 source "$( pwd )/env.sh"
 
 OUTPUT_DIRECTORY="${OUTPUT_DIRECTORY:-$PWD/backups}"
-SOURCE_DATABASE=$( node scripts/generate_config.js |jq --raw-output '.config.components.storage.database' )
+SOURCE_DATABASE=$( node scripts/generate_config.js |jq --raw-output '.components.storage.database' )
 
 mkdir -p "$OUTPUT_DIRECTORY"
 


### PR DESCRIPTION
### What was the problem?

Configuration structure has changed; `lisk_snapshot.sh` needs to be adapted.

### How did I fix it?

Changed configuration key in `lisk_snapshot.sh`.

### How to test it?

Run `lisk_snapshot.sh`.

### Review checklist

* The PR resolves #55 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
