### PR TITLE
Abort Jenkins build if there it already exists

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,6 +15,7 @@ pipeline {
 				VERSION=$( jq --raw-output '.version' package.json )
 				SHORT_HASH=$( git rev-parse --short HEAD )
 				echo "$VERSION-$SHORT_HASH" >.lisk_version
+				OUTPUT_FILE="lisk-$( cat .lisk_version )-Linux-x86_64.tar.gz"
 				if s3cmd --quiet info "s3://lisk-releases/lisk-core/$OUTPUT_FILE" 2>/dev/null; then
 				  echo "Build already exists."
 				  exit 1


### PR DESCRIPTION
### What was the problem?

Jenkins build would not be aborted if a build for the same commit already existed.

### How did I fix it?

Fix the check for existing build.

### How to test it?

Try running the Jenkins job to create a build for the same commit twice; the second one should fail.

### Review checklist

* The PR resolves #58 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
