### PR TITLE
Expose redis and postgresql metrics on Kubernetes - Closes #62

### DIFF
--- a/helm/lisk-core/templates/lisk-core-service.yaml
+++ b/helm/lisk-core/templates/lisk-core-service.yaml
@@ -19,6 +19,18 @@ spec:
       port: {{ .Values.lisk.wsPort }}
       targetPort: lisk-core-ws
       protocol: TCP
+    {{- if .Values.redis.monitoring.enabled }}
+    - name: redis-metrics
+      port: 9121
+      targetPort: redis-metrics
+      protocol: TCP
+    {{- end }}
+    {{- if .Values.postgresql.monitoring.enabled }}
+    - name: pg-metrics
+      port: 9187
+      targetPort: pg-metrics
+      protocol: TCP
+    {{- end }}
   selector:
     app.kubernetes.io/name: "{{ include "lisk-core.name" . }}"
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/helm/lisk-core/templates/lisk-core-statefulset.yaml
+++ b/helm/lisk-core/templates/lisk-core-statefulset.yaml
@@ -149,6 +149,20 @@ spec:
               value: {{ .Values.lisk.network }}
             - name: POSTGRES_PASSWORD
               value: {{ .Values.lisk.database.password }}
+        {{- if .Values.postgresql.monitoring.enabled }}
+        - name: postgresql-exporter
+          image: {{ .Values.postgresql.monitoring.image.repository }}:{{ .Values.postgresql.monitoring.image.tag }}
+          env:
+            - name: DATA_SOURCE_USER
+              value: {{ .Values.lisk.database.user }}
+            - name: DATA_SOURCE_URI
+              value: "127.0.0.1:5432/{{ .Values.lisk.network }}?sslmode=disable"
+            - name: DATA_SOURCE_PASS
+              value: {{ .Values.lisk.database.password }}
+          ports:
+            - name: pg-metrics
+              containerPort: 9187
+        {{- end }}
         {{- if .Values.redis.enabled }}
         - name: redis
           image: {{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}
@@ -166,6 +180,18 @@ spec:
             - ""
           resources:
 {{ toYaml .Values.redis.resources | indent 12 }}
+        {{- if .Values.redis.monitoring.enabled }}
+        - name: redis-exporter
+          image: {{ .Values.redis.monitoring.image.repository }}:{{ .Values.redis.monitoring.image.tag }}
+          env:
+            - name: REDIS_ALIAS
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          ports:
+            - name: redis-metrics
+              containerPort: 9121
+        {{- end }}
         {{- end }}
       {{- if .Values.affinity }}
       affinity:

--- a/helm/lisk-core/templates/postgresql-servicemonitor.yaml
+++ b/helm/lisk-core/templates/postgresql-servicemonitor.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.postgresql.monitoring.enabled .Values.postgresql.monitoring.serviceMonitor }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/name: "{{ include "lisk-core.name" . }}"
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "lisk-core.chart" . }}
+  name: "{{ include "lisk-core.name" . }}-postgresql"
+spec:
+  endpoints:
+    - port: pg-metrics
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: "{{ .Release.Name }}-lisk-core"
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/helm/lisk-core/templates/redis-servicemonitor.yaml
+++ b/helm/lisk-core/templates/redis-servicemonitor.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.redis.monitoring.enabled .Values.redis.monitoring.serviceMonitor }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/name: "{{ include "lisk-core.name" . }}"
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "lisk-core.chart" . }}
+  name: "{{ include "lisk-core.name" . }}-redis"
+spec:
+  endpoints:
+    - port: redis-metrics
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: "{{ .Release.Name }}-lisk-core"
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/helm/lisk-core/values.yaml
+++ b/helm/lisk-core/values.yaml
@@ -39,6 +39,12 @@ postgresql:
   persistence:
     enable: true
     storage: 10Gi
+  monitoring:
+    enabled: false
+    serviceMonitor: false
+    image:
+      repository: wrouesnel/postgres_exporter
+      tag: v0.4.7
   image:
     repository: postgres
     tag: 10-alpine
@@ -56,6 +62,12 @@ postgresql:
 
 redis:
   enabled: true
+  monitoring:
+    enabled: false
+    serviceMonitor: false
+    image:
+      repository: oliver006/redis_exporter
+      tag: v0.34.1
   image:
     repository: redis
     tag: 5-alpine


### PR DESCRIPTION
### What was the problem?
Metrics for redis and postgresql weren't available.

### How did I fix it?
Added prometheus exporters containers as sidecar on lisk-core pod.

### How to test it?
Deploy helm chart enabling monitoring in values file

### Review checklist

* The PR resolves #62 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
