### PR TITLE
Update update_config.js - Closes #65

### DIFF
--- a/scripts/update_config.js
+++ b/scripts/update_config.js
@@ -312,7 +312,11 @@ history.version('2.0.0-alpha.0', version => {
 			'peers.options.wsEngine',
 			'modules.network.wsEngine'
 		);
-		config = moveElement(config, 'modules.chain.broadcasts.broadcastLimit', 'modules.network.emitPeerLimit');
+		config = moveElement(
+			config,
+			'modules.chain.broadcasts.broadcastLimit',
+			'modules.network.emitPeerLimit'
+		);
 		config = moveElement(config, 'wsPort', 'modules.network.wsPort');
 		config = moveElement(config, 'address', 'modules.network.address');
 		delete config.peers;

--- a/scripts/update_config.js
+++ b/scripts/update_config.js
@@ -312,6 +312,7 @@ history.version('2.0.0-alpha.0', version => {
 			'peers.options.wsEngine',
 			'modules.network.wsEngine'
 		);
+		config = moveElement(config, 'modules.chain.broadcasts.broadcastLimit', 'modules.network.emitPeerLimit');
 		config = moveElement(config, 'wsPort', 'modules.network.wsPort');
 		config = moveElement(config, 'address', 'modules.network.address');
 		delete config.peers;


### PR DESCRIPTION
### What was the problem?
broadcastLimit was move from chain module config to network module config.

### How did I fix it?
Add a task to move broadcastLimit to network module config

### How to test it?
run update_config.js with config of `1.6.0`

### Review checklist

* The PR resolves #6 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
