### PR TITLE
Ensure NETWORK variable gets expanded - Closes #68

### DIFF
--- a/qa/Jenkinsfile
+++ b/qa/Jenkinsfile
@@ -112,7 +112,7 @@ lisk_version: ${env.LISK_VERSION}""",
             templateType: 'job',
             jobTemplate: '16',  // devnet-archive-logs
             jobType: 'run',
-            extraVars: "devnet: ${params.NETWORK}",
+            extraVars: """devnet: ${params.NETWORK}""",
             throwExceptionWhenFail: false,
             verbose: false
         }
@@ -127,7 +127,7 @@ lisk_version: ${env.LISK_VERSION}""",
             templateType: 'job',
             jobTemplate: '15',  // do-destroy-tag
             jobType: 'run',
-            extraVars: "do_tag: ${params.NETWORK}_node",
+            extraVars: """do_tag: ${params.NETWORK}_node""",
             throwExceptionWhenFail: false,
             verbose: false
         } else {


### PR DESCRIPTION
### What was the problem?

With the default parameter for `NETWORK` the nodes would not be destroyed.

### How did I fix it?

Make sure `NETWORK` variable will be expanded.

### How to test it?

Run Jenkins job with default parameters then ensure nodes got destroyed.

### Review checklist

* The PR resolves #68 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
