### PR TITLE
Update registerTransaction matcher usage - Closes #70

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,22 +18,15 @@ try {
 	// tslint:disable-next-line no-var-requires
 	const genesisBlock = require(`../config/${NETWORK}/genesis_block.json`);
 
-	const TRANSACTION_TYPES = {
-		DAPP: 5,
-		IN_TRANSFER: 6,
-		OUT_TRANSFER: 7,
-	};
-
 	const app = new Application(genesisBlock, config);
 
-	app.registerTransaction(TRANSACTION_TYPES.DAPP, DappTransaction, {
+	app.registerTransaction(DappTransaction, {
 		matcher: context =>
 			context.blockHeight <
 			app.config.modules.chain.exceptions.precedent.disableDappTransaction,
 	});
 
 	app.registerTransaction(
-		TRANSACTION_TYPES.IN_TRANSFER,
 		InTransferTransaction,
 		{
 			matcher: context =>
@@ -43,7 +36,6 @@ try {
 	);
 
 	app.registerTransaction(
-		TRANSACTION_TYPES.OUT_TRANSFER,
 		OutTransferTransaction,
 		{
 			matcher: context =>

--- a/src/transactions/5_dapp_transaction.ts
+++ b/src/transactions/5_dapp_transaction.ts
@@ -21,7 +21,7 @@ import {
 	TransactionJSON,
 	utils,
 } from '@liskhq/lisk-transactions';
-import { DAPP_FEE, TRANSACTION_DAPP_TYPE } from './constants';
+import { DAPP_FEE } from './constants';
 
 const { validator, stringEndsWith } = utils;
 
@@ -93,6 +93,7 @@ export const dappAssetFormatSchema = {
 export class DappTransaction extends BaseTransaction {
 	public readonly containsUniqueData: boolean;
 	public readonly asset: DappAsset;
+	public static TYPE = 5;
 
 	public constructor(rawTransaction: unknown) {
 		super(rawTransaction);
@@ -214,18 +215,6 @@ export class DappTransaction extends BaseTransaction {
 			validator.errors
 		) as TransactionError[];
 
-		if (this.type !== TRANSACTION_DAPP_TYPE) {
-			errors.push(
-				new TransactionError(
-					'Invalid type',
-					this.id,
-					'.type',
-					this.type,
-					TRANSACTION_DAPP_TYPE
-				)
-			);
-		}
-
 		if (!this.amount.eq(0)) {
 			errors.push(
 				new TransactionError(
@@ -318,7 +307,7 @@ export class DappTransaction extends BaseTransaction {
 		const errors: TransactionError[] = [];
 		const nameExists = store.transaction.find(
 			(transaction: TransactionJSON) =>
-				transaction.type === TRANSACTION_DAPP_TYPE &&
+				transaction.type === this.type &&
 				transaction.id !== this.id &&
 				(transaction.asset as DappAsset).dapp &&
 				(transaction.asset as DappAsset).dapp.name === this.asset.dapp.name
@@ -336,7 +325,7 @@ export class DappTransaction extends BaseTransaction {
 
 		const linkExists = store.transaction.find(
 			(transaction: TransactionJSON) =>
-				transaction.type === TRANSACTION_DAPP_TYPE &&
+				transaction.type === this.type &&
 				transaction.id !== this.id &&
 				(transaction.asset as DappAsset).dapp &&
 				(transaction.asset as DappAsset).dapp.link === this.asset.dapp.link

--- a/src/transactions/5_dapp_transaction.ts
+++ b/src/transactions/5_dapp_transaction.ts
@@ -307,7 +307,7 @@ export class DappTransaction extends BaseTransaction {
 		const errors: TransactionError[] = [];
 		const nameExists = store.transaction.find(
 			(transaction: TransactionJSON) =>
-				transaction.type === this.type &&
+				transaction.type === DappTransaction.TYPE &&
 				transaction.id !== this.id &&
 				(transaction.asset as DappAsset).dapp &&
 				(transaction.asset as DappAsset).dapp.name === this.asset.dapp.name
@@ -325,7 +325,7 @@ export class DappTransaction extends BaseTransaction {
 
 		const linkExists = store.transaction.find(
 			(transaction: TransactionJSON) =>
-				transaction.type === this.type &&
+				transaction.type === DappTransaction.TYPE &&
 				transaction.id !== this.id &&
 				(transaction.asset as DappAsset).dapp &&
 				(transaction.asset as DappAsset).dapp.link === this.asset.dapp.link

--- a/src/transactions/6_in_transfer_transaction.ts
+++ b/src/transactions/6_in_transfer_transaction.ts
@@ -23,9 +23,8 @@ import {
 	utils,
 } from '@liskhq/lisk-transactions';
 import {
-	IN_TRANSFER_FEE,
 	TRANSACTION_DAPP_TYPE,
-	TRANSACTION_INTRANSFER_TYPE,
+	IN_TRANSFER_FEE,
 } from './constants';
 
 const { convertBeddowsToLSK, verifyAmountBalance, validator } = utils;
@@ -55,6 +54,7 @@ export const inTransferAssetFormatSchema = {
 
 export class InTransferTransaction extends BaseTransaction {
 	public readonly asset: InTransferAsset;
+	public static TYPE = 6;
 
 	public constructor(rawTransaction: unknown) {
 		super(rawTransaction);
@@ -111,18 +111,6 @@ export class InTransferTransaction extends BaseTransaction {
 			this.id,
 			validator.errors
 		) as TransactionError[];
-
-		if (this.type !== TRANSACTION_INTRANSFER_TYPE) {
-			errors.push(
-				new TransactionError(
-					'Invalid type',
-					this.id,
-					'.type',
-					this.type,
-					TRANSACTION_INTRANSFER_TYPE
-				)
-			);
-		}
 
 		// Per current protocol, this recipientId and recipientPublicKey must be empty
 		if (this.recipientId) {

--- a/src/transactions/7_out_transfer_transaction.ts
+++ b/src/transactions/7_out_transfer_transaction.ts
@@ -25,7 +25,6 @@ import {
 import { MAX_TRANSACTION_AMOUNT, OUT_TRANSFER_FEE } from './constants';
 
 const { verifyAmountBalance, validator } = utils;
-const TRANSACTION_OUTTRANSFER_TYPE = 7;
 const TRANSACTION_DAPP_REGISTERATION_TYPE = 5;
 
 export interface OutTransferAsset {
@@ -59,6 +58,7 @@ export const outTransferAssetFormatSchema = {
 export class OutTransferTransaction extends BaseTransaction {
 	public readonly asset: OutTransferAsset;
 	public readonly containsUniqueData: boolean;
+	public static TYPE = 7;
 
 	public constructor(rawTransaction: unknown) {
 		super(rawTransaction);
@@ -126,18 +126,6 @@ export class OutTransferTransaction extends BaseTransaction {
 			this.id,
 			validator.errors
 		) as TransactionError[];
-
-		if (this.type !== TRANSACTION_OUTTRANSFER_TYPE) {
-			errors.push(
-				new TransactionError(
-					'Invalid type',
-					this.id,
-					'.type',
-					this.type,
-					TRANSACTION_OUTTRANSFER_TYPE
-				)
-			);
-		}
 
 		// Amount has to be greater than 0
 		if (this.amount.lte(0)) {

--- a/src/transactions/7_out_transfer_transaction.ts
+++ b/src/transactions/7_out_transfer_transaction.ts
@@ -103,7 +103,7 @@ export class OutTransferTransaction extends BaseTransaction {
 	): ReadonlyArray<TransactionError> {
 		const sameTypeTransactions = transactions.filter(
 			tx =>
-				tx.type === this.type &&
+				tx.type === OutTransferTransaction.TYPE &&
 				'outTransfer' in tx.asset &&
 				this.asset.outTransfer.transactionId ===
 					(tx.asset as OutTransferAsset).outTransfer.transactionId

--- a/src/transactions/constants.ts
+++ b/src/transactions/constants.ts
@@ -18,8 +18,6 @@ import { constants } from '@liskhq/lisk-transactions';
 const { FIXED_POINT, MAX_TRANSACTION_AMOUNT } = constants;
 
 export const TRANSACTION_DAPP_TYPE = 5;
-export const TRANSACTION_INTRANSFER_TYPE = 6;
-export const TRANSACTION_OUTTRANSFER_TYPE = 7;
 
 export const IN_TRANSFER_FEE = FIXED_POINT * 0.1;
 export const OUT_TRANSFER_FEE = FIXED_POINT * 0.1;


### PR DESCRIPTION
### What was the problem?

`registerTransaction` was modified in `lisk-sdk` framework. Changes need to be reflected in core.

### How did I fix it?

Updated `registerTransaction` calls in core.

### Review checklist

* The PR resolves #70 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
