### PR TITLE
Fix update config - Closes #78

### DIFF
--- a/scripts/update_config.js
+++ b/scripts/update_config.js
@@ -297,6 +297,13 @@ history.version('2.0.0-alpha.0', version => {
 
 	version.change('add structure for network module', config => {
 		config = moveElement(config, 'peers.list', 'modules.network.seedPeers');
+		// Change wsPort to number
+		if (config.modules && config.modules.network && config.modules.network.seedPeers) {
+			config.modules.network.seedPeers = config.modules.network.seedPeers.map(peer => ({
+				...peer,
+				wsPort: parseInt(peer.wsPort),
+			}));
+		}
 		config = moveElement(
 			config,
 			'peers.access.blackList',

--- a/test/fixtures/config_1.6.json
+++ b/test/fixtures/config_1.6.json
@@ -1,0 +1,109 @@
+{
+	"wsPort": 6000,
+	"httpPort": 3000,
+	"address": "0.0.0.0",
+	"fileLogLevel": "info",
+	"logFileName": "logs/lisk.log",
+	"consoleLogLevel": "none",
+	"trustProxy": false,
+	"topAccounts": false,
+	"cacheEnabled": false,
+	"db": {
+		"host": "localhost",
+		"port": 5432,
+		"database": "",
+		"user": "lisk",
+		"password": "password",
+		"min": 10,
+		"max": 95,
+		"poolIdleTimeout": 30000,
+		"reapIntervalMillis": 1000,
+		"logEvents": [
+			"error"
+		],
+		"logFileName": "logs/lisk_db.log"
+	},
+	"redis": {
+		"host": "127.0.0.1",
+		"port": 6380,
+		"db": 0,
+		"password": null
+	},
+	"ipc": {
+		"enabled": false
+	},
+	"api": {
+		"enabled": true,
+		"access": {
+			"public": false,
+			"whiteList": [
+				"127.0.0.1"
+			]
+		},
+		"ssl": {
+			"enabled": false,
+			"options": {
+				"port": 443,
+				"address": "0.0.0.0",
+				"key": "./ssl/lisk.key",
+				"cert": "./ssl/lisk.crt"
+			}
+		},
+		"options": {
+			"limits": {
+				"max": 0,
+				"delayMs": 0,
+				"delayAfter": 0,
+				"windowMs": 60000,
+				"headersTimeout": 5000,
+				"serverSetTimeout": 20000
+			},
+			"cors": {
+				"origin": "*",
+				"methods": [
+					"GET",
+					"POST",
+					"PUT"
+				]
+			}
+		}
+	},
+	"peers": {
+		"enabled": true,
+		"list": [],
+		"access": {
+			"blackList": []
+		},
+		"options": {
+			"timeout": 5000,
+			"broadhashConsensusCalculationInterval": 5000,
+			"wsEngine": "ws"
+		}
+	},
+	"broadcasts": {
+		"active": true,
+		"broadcastInterval": 5000,
+		"broadcastLimit": 25,
+		"parallelLimit": 20,
+		"releaseLimit": 25,
+		"relayLimit": 3
+	},
+	"transactions": {
+		"maxTransactionsPerQueue": 1000
+	},
+	"forging": {
+		"force": false,
+		"delegates": [],
+		"access": {
+			"whiteList": [
+				"127.0.0.1"
+			]
+		}
+	},
+	"syncing": {
+		"active": true
+	},
+	"loading": {
+		"loadPerIteration": 5000
+	}
+}

--- a/test/unit/scripts/update_config.js
+++ b/test/unit/scripts/update_config.js
@@ -17,17 +17,18 @@
 const path = require('path');
 const fs = require('fs');
 const { spawnSync } = require('child_process');
+const { Application } = require('lisk-sdk')
+const originalConfig = require('../../fixtures/config_1.6.json');
+const genesisBlock = require('../../../config/devnet/genesis_block.json');
 
 const dirPath = __dirname;
 const rootPath = path.dirname(path.resolve(__filename, '../../../'));
 
 // TODO: Enable again after the issue https://github.com/LiskHQ/lisk/issues/3171
 // eslint-disable-next-line mocha/no-skipped-tests
-describe.skip('scripts/update_config', () => {
-	const testedConfigPath = `${dirPath}/tested_config.json`;
+describe('scripts/update_config', () => {
 	const updatedConfigPath = `${dirPath}/updated_config.json`;
 	let spawnedScript;
-	let testedConfig;
 	let updatedConfig;
 
 	before(async () => {
@@ -39,12 +40,11 @@ describe.skip('scripts/update_config', () => {
 				'testnet',
 				'--output',
 				updatedConfigPath,
-				testedConfigPath,
-				'1.0.0',
+				originalConfig,
+				'1.6.0',
 			],
 			{ cwd: rootPath }
 		);
-		testedConfig = fs.readFileSync(`${dirPath}/tested_config.json`);
 		updatedConfig = fs.readFileSync(`${dirPath}/updated_config.json`);
 	});
 
@@ -56,10 +56,7 @@ describe.skip('scripts/update_config', () => {
 		expect(spawnedScript.stderr.toString()).to.be.empty;
 	});
 
-	it('should create an updated file equal to the tested file', async () => {
-		const testedConfigJson = JSON.parse(testedConfig.toString());
-		const updatedConfigJson = JSON.parse(updatedConfig.toString());
-
-		expect(testedConfigJson).to.deep.eql(updatedConfigJson);
+	it('should be able to instanciate application', async () => {
+			expect(() => new Application(genesisBlock, updatedConfig)).not.to.throw;
 	});
 });


### PR DESCRIPTION
### What was the problem?
WSPort was changed from string to number

### How did I fix it?
Update WSPort to be changed from string to number

### How to test it?
`node scripts/update_config.js config.json 1.6.0 2.0.0 -n testnet` and use it for lisk-core
`npm t`

### Review checklist

* The PR resolves #78
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
