### PR TITLE
update_config not migrating forging.access correctly #88

### DIFF
--- a/scripts/update_config.js
+++ b/scripts/update_config.js
@@ -335,11 +335,11 @@ history.version('2.0.0-rc.0', version => {
 		return config;
 	});
 
-	version.change('move forging.access to http_api', config => {
+	version.change('move forging.access to modules.http_api.forging.access', config => {
 		config = moveElement(
 			config,
 			'modules.chain.forging.access',
-			'modules.http_api.forging'
+			'modules.http_api.forging.access'
 		);
 		return config;
 	});


### PR DESCRIPTION
### What was the problem?
The property `access` was missing when migrating `forging.access` property on update_config.js

### How did I fix it?
By adding the missing property

### How to test it?
Run `node scripts/update_config.js -n testnet -o new.config.json local.config.json 1.6.0` with `local.config.json` containing:
```
"forging": {
        "access": {
			"whiteList": ["0.0.0.0"]
		},
    }
```

### Review checklist

* The PR resolves #88
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
