### PR TITLE
Ensure docker containers are restarted after reboot/restart of the daemon - Close #98

### DIFF
--- a/docker/docker-compose.redis.yml
+++ b/docker/docker-compose.redis.yml
@@ -15,5 +15,5 @@ services:
     image: redis:alpine
     networks:
       - lisk
-    restart: on-failure
+    restart: unless-stopped
     command: --maxclients 500 --tcp-backlog 128 --maxmemory-policy allkeys-lru --save ""

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - lisk
     depends_on:
       - db
-    restart: on-failure
+    restart: unless-stopped
     entrypoint: ["/home/lisk/wait-for-it.sh", "db:5432", "--", "node", "/home/lisk/lisk/dist/index.js"]
     command: ["-n", "${ENV_LISK_NETWORK}"]
     environment:
@@ -33,7 +33,7 @@ services:
       - db-data:/var/lib/postgresql/data
     networks:
       - lisk
-    restart: on-failure
+    restart: unless-stopped
     environment:
       - POSTGRES_DB=${ENV_LISK_DB_DATABASE}
       - POSTGRES_PASSWORD=${ENV_LISK_DB_PASSWORD}


### PR DESCRIPTION
### What was the problem?
Containers might not be running after a reboot / restart of the docker deamon.

### How did I fix it?
Use the `unless-stopped` restart policy.
> Always restart the container regardless of the exit status, including on daemon startup, except if the container was put into a stopped state before the Docker daemon was stopped.

From https://docs.docker.com/engine/reference/run/#restart-policies---restart

### How to test it?

1. Create containers
```
$ cd docker
$ cp .env.testnet .env
$ make
```
2. Reboot
```
# reboot
```
3. Check that the containers are running again
```
$ docker ps
```

### Review checklist

* The PR resolves #98 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
