### PR TITLE
Update transactions to use FEE property - Closes #100

### DIFF
--- a/src/transactions/5_dapp_transaction.ts
+++ b/src/transactions/5_dapp_transaction.ts
@@ -94,6 +94,7 @@ export class DappTransaction extends BaseTransaction {
 	public readonly containsUniqueData: boolean;
 	public readonly asset: DappAsset;
 	public static TYPE = 5;
+	public static FEE = DAPP_FEE.toString();
 
 	public constructor(rawTransaction: unknown) {
 		super(rawTransaction);
@@ -237,17 +238,6 @@ export class DappTransaction extends BaseTransaction {
 			);
 		}
 
-		if (!this.fee.eq(DAPP_FEE)) {
-			errors.push(
-				new TransactionError(
-					`Fee must be equal to ${DAPP_FEE}`,
-					this.id,
-					'.fee',
-					this.fee.toString(),
-					DAPP_FEE
-				)
-			);
-		}
 		const validLinkSuffix = ['.zip'];
 
 		if (errors.length > 0) {

--- a/src/transactions/6_in_transfer_transaction.ts
+++ b/src/transactions/6_in_transfer_transaction.ts
@@ -55,6 +55,7 @@ export const inTransferAssetFormatSchema = {
 export class InTransferTransaction extends BaseTransaction {
 	public readonly asset: InTransferAsset;
 	public static TYPE = 6;
+	public static FEE = IN_TRANSFER_FEE.toString();
 
 	public constructor(rawTransaction: unknown) {
 		super(rawTransaction);
@@ -143,18 +144,6 @@ export class InTransferTransaction extends BaseTransaction {
 					'.amount',
 					this.amount.toString(),
 					'0'
-				)
-			);
-		}
-
-		if (!this.fee.eq(IN_TRANSFER_FEE)) {
-			errors.push(
-				new TransactionError(
-					`Fee must be equal to ${IN_TRANSFER_FEE}`,
-					this.id,
-					'.fee',
-					this.fee.toString(),
-					IN_TRANSFER_FEE
 				)
 			);
 		}

--- a/src/transactions/7_out_transfer_transaction.ts
+++ b/src/transactions/7_out_transfer_transaction.ts
@@ -59,6 +59,7 @@ export class OutTransferTransaction extends BaseTransaction {
 	public readonly asset: OutTransferAsset;
 	public readonly containsUniqueData: boolean;
 	public static TYPE = 7;
+	public static FEE = OUT_TRANSFER_FEE.toString();
 
 	public constructor(rawTransaction: unknown) {
 		super(rawTransaction);
@@ -135,18 +136,6 @@ export class OutTransferTransaction extends BaseTransaction {
 					this.id,
 					'.amount',
 					this.amount.toString()
-				)
-			);
-		}
-
-		if (!this.fee.eq(OUT_TRANSFER_FEE)) {
-			errors.push(
-				new TransactionError(
-					`Fee must be equal to ${OUT_TRANSFER_FEE}`,
-					this.id,
-					'.fee',
-					this.fee.toString(),
-					OUT_TRANSFER_FEE
 				)
 			);
 		}


### PR DESCRIPTION
### What was the problem?

We added the FEE member to lisk-transactions and Dapp, in/out needed to be updated
This transactions are disabled currently but this PR is to keep consistency with lisk-transactions

### How did I fix it?

By adding the FEE member to the custom transactions defined in core

### How to test it?

- Build should be green
- Run core and check it works correctly

### Review checklist

* The PR resolves #100
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
