### PR TITLE
Separate Jenkins job to create network and run tests independently - Closes #103

### DIFF
--- a/qa/Jenkinsfile.network
+++ b/qa/Jenkinsfile.network
@@ -55,7 +55,7 @@ lisk_version: ${env.LISK_VERSION}""",
     }
     stage('Generate peer config and enable forging') {
       options {
-        timeout(time: 10, unit: 'MINUTES')
+        timeout(time: 20, unit: 'MINUTES')
       }
       steps {
         dir('qa') {

--- a/qa/Jenkinsfile.network
+++ b/qa/Jenkinsfile.network
@@ -53,6 +53,23 @@ lisk_version: ${env.LISK_VERSION}""",
         }
       }
     }
+    stage('Generate peer config and enable forging') {
+      options {
+        timeout(time: 10, unit: 'MINUTES')
+      }
+      steps {
+        dir('qa') {
+          nvm(getNodejsVersion()) {
+            sh '''
+            npm run tools:peers:seed:node
+            npm run tools:peers:network:nodes
+            npm run tools:peers:connected
+            npm run tools:delegates:enable
+            '''
+          }
+        }
+      }
+    }
   }
   post {
     failure {

--- a/qa/Jenkinsfile.network
+++ b/qa/Jenkinsfile.network
@@ -4,8 +4,9 @@ properties([
   parameters([
     string(name: 'SDK_BRANCH_NAME', defaultValue: 'development', description: 'Lisk core branch name', ),
     string(name: 'CORE_BRANCH_NAME', defaultValue: 'master', description: 'Lisk core branch name', ),
-    string(name: 'NETWORK', defaultValue: 'jenkinsnet-$BUILD_ID', description: 'To Run test against a network', ),
+    string(name: 'NETWORK', defaultValue: 'alphanet-$BUILD_ID', description: 'To Run test against a network', ),
     string(name: 'NODES_PER_REGION', defaultValue: '1', description: 'Number of nodes per region', ),
+    string(name: 'NEWRELIC_ENABLED', defaultValue: 'no', description: 'Enable NewRelic', ),
   ])
 ])
 

--- a/qa/Jenkinsfile.network
+++ b/qa/Jenkinsfile.network
@@ -1,0 +1,63 @@
+@Library('lisk-jenkins') _
+
+properties([
+  parameters([
+    string(name: 'SDK_BRANCH_NAME', defaultValue: 'development', description: 'Lisk core branch name', ),
+    string(name: 'CORE_BRANCH_NAME', defaultValue: 'master', description: 'Lisk core branch name', ),
+    string(name: 'NETWORK', defaultValue: 'jenkinsnet-$BUILD_ID', description: 'To Run test against a network', ),
+    string(name: 'NODES_PER_REGION', defaultValue: '1', description: 'Number of nodes per region', ),
+  ])
+])
+
+pipeline {
+  agent { node { label 'lisk-core' } }
+  options { disableConcurrentBuilds() }
+  stages {
+    stage('Build') {
+      steps {
+        dir('qa') {
+          nvm(getNodejsVersion()) {
+            sh 'npm ci'
+          }
+        }
+      }
+    }
+    stage('Trigger core build') {
+      steps {
+        script {
+          def b = build job: 'lisk-qa/lisk-core-build-dev',
+                  parameters: [string(name: 'COMMITISH_SDK', value: """${params.SDK_BRANCH_NAME}"""),
+                   string(name: 'COMMITISH_CORE', value: """${params.CORE_BRANCH_NAME}""")]
+          env.LISK_VERSION = b.getBuildVariables().get('LISK_VERSION')
+        }
+      }
+    }
+    stage('Deploy network') {
+      steps {
+        retry(5) {
+          ansiColor('xterm') {
+            ansibleTower \
+              towerServer: 'tower',
+              templateType: 'job',
+              jobTemplate: '14',  // devnet-deploy
+              jobType: 'run',
+              extraVars: """newrelic_enabled: '${params.NEWRELIC_ENABLED}'
+devnet: ${params.NETWORK}
+do_nodes_per_region: ${params.NODES_PER_REGION}
+jenkins_ci: 'yes'
+lisk_version: ${env.LISK_VERSION}""",
+              importTowerLogs: true,
+              throwExceptionWhenFail: true,
+              verbose: false
+          }
+        }
+      }
+    }
+  }
+  post {
+    failure {
+      liskSlackSend('danger', "Build failed (<${env.BUILD_URL}/console|console>, <${env.BUILD_URL}/changes|changes>)", 'lisk-ci-core')
+    }
+  }
+}
+// vim: filetype=groovy

--- a/qa/Jenkinsfile.network_destroy
+++ b/qa/Jenkinsfile.network_destroy
@@ -1,0 +1,56 @@
+@Library('lisk-jenkins') _
+
+properties([
+  parameters([
+    string(name: 'NETWORK', description: 'Network to destroy', ),
+  ])
+])
+
+pipeline {
+  agent { node { label 'lisk-core' } }
+  options { disableConcurrentBuilds() }
+  stages {
+    stage('Destroy network') {
+      steps {
+        script {
+          ansibleTower \
+            towerServer: 'tower',
+            templateType: 'job',
+            jobTemplate: '16',  // devnet-archive-logs
+            jobType: 'run',
+            extraVars: """devnet: ${params.NETWORK}""",
+            throwExceptionWhenFail: false,
+            verbose: false
+        }
+      }
+    }
+  }
+  post {
+    failure {
+      script {
+        ansibleTower \
+          towerServer: 'tower',
+          templateType: 'job',
+          jobTemplate: '16',  // devnet-archive-logs
+          jobType: 'run',
+          extraVars: """devnet: ${params.NETWORK}""",
+          throwExceptionWhenFail: false,
+          verbose: false
+      }
+      liskSlackSend('danger', "Build failed (<${env.BUILD_URL}/console|console>, <${env.BUILD_URL}/changes|changes>)", 'lisk-ci-core')
+    }
+    cleanup {
+      script {
+        ansibleTower \
+          towerServer: 'tower',
+          templateType: 'job',
+          jobTemplate: '15',  // do-destroy-tag
+          jobType: 'run',
+          extraVars: """do_tag: ${params.NETWORK}_node""",
+          throwExceptionWhenFail: false,
+          verbose: false
+      }
+    }
+  }
+}
+// vim: filetype=groovy

--- a/qa/Jenkinsfile.network_test
+++ b/qa/Jenkinsfile.network_test
@@ -48,6 +48,8 @@ pipeline {
           dir('qa') {
             nvm(getNodejsVersion()) {
               ansiColor('xterm') {
+                sh 'npm run tools:peers:seed:node'
+                sh 'npm run tools:peers:network:nodes'
                 sh 'npm run stress:generic || true'
                 sh 'npm run stress:diversified'
               }

--- a/qa/Jenkinsfile.network_test
+++ b/qa/Jenkinsfile.network_test
@@ -4,7 +4,7 @@ properties([
   parameters([
     string(name: 'NETWORK', description: 'To Run test against a network', ),
     string(name: 'STRESS_COUNT', defaultValue: '500', description: 'Number of transactions to create', ), // Used by stage: Test Network Stress
-    booleanParam(name: 'CLEAN_UP', defaultValue: true, description: 'Destroy deployed nodes when done testing', ),
+    booleanParam(name: 'CLEAN_UP', defaultValue: false, description: 'Destroy deployed nodes when done testing', ),
   ])
 ])
 

--- a/qa/Jenkinsfile.network_test
+++ b/qa/Jenkinsfile.network_test
@@ -17,6 +17,8 @@ pipeline {
         dir('qa') {
           nvm(getNodejsVersion()) {
             sh 'npm ci'
+            sh 'npm run tools:peers:seed:node'
+            sh 'npm run tools:peers:network:nodes'
           }
         }
       }
@@ -48,8 +50,6 @@ pipeline {
           dir('qa') {
             nvm(getNodejsVersion()) {
               ansiColor('xterm') {
-                sh 'npm run tools:peers:seed:node'
-                sh 'npm run tools:peers:network:nodes'
                 sh 'npm run stress:generic || true'
                 sh 'npm run stress:diversified'
               }

--- a/qa/Jenkinsfile.network_test
+++ b/qa/Jenkinsfile.network_test
@@ -2,9 +2,8 @@
 
 properties([
   parameters([
-    string(name: 'NETWORK', defaultValue: 'jenkinsnet-$BUILD_ID', description: 'To Run test against a network', ),
+    string(name: 'NETWORK', description: 'To Run test against a network', ),
     string(name: 'STRESS_COUNT', defaultValue: '500', description: 'Number of transactions to create', ), // Used by stage: Test Network Stress
-    string(name: 'NEWRELIC_ENABLED', defaultValue: 'no', description: 'Enable NewRelic', ),
     booleanParam(name: 'CLEAN_UP', defaultValue: true, description: 'Destroy deployed nodes when done testing', ),
   ])
 ])

--- a/qa/Jenkinsfile.network_test
+++ b/qa/Jenkinsfile.network_test
@@ -1,0 +1,98 @@
+@Library('lisk-jenkins') _
+
+properties([
+  parameters([
+    string(name: 'NETWORK', defaultValue: 'jenkinsnet-$BUILD_ID', description: 'To Run test against a network', ),
+    string(name: 'STRESS_COUNT', defaultValue: '500', description: 'Number of transactions to create', ), // Used by stage: Test Network Stress
+    string(name: 'NEWRELIC_ENABLED', defaultValue: 'no', description: 'Enable NewRelic', ),
+    booleanParam(name: 'CLEAN_UP', defaultValue: true, description: 'Destroy deployed nodes when done testing', ),
+  ])
+])
+
+pipeline {
+  agent { node { label 'lisk-core' } }
+  options { disableConcurrentBuilds() }
+  stages {
+    stage('Build') {
+      steps {
+        dir('qa') {
+          nvm(getNodejsVersion()) {
+            sh 'npm ci'
+          }
+        }
+      }
+    }
+    stage('Test Scenarios') {
+      options {
+        timeout(time: 30, unit: 'MINUTES')
+      }
+      steps {
+        retry(2) {
+          timestamps {
+            dir('qa') {
+              nvm(getNodejsVersion()) {
+                ansiColor('xterm') {
+                  sh 'npm run features || true'
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    stage('Test Network Stress') {
+      options {
+        timeout(time: 1, unit: 'HOURS')
+      }
+      steps {
+        timestamps {
+          dir('qa') {
+            nvm(getNodejsVersion()) {
+              ansiColor('xterm') {
+                sh 'npm run stress:generic || true'
+                sh 'npm run stress:diversified'
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  post {
+    always {
+      allure includeProperties: false, jdk: '', results: [[path: 'qa/output']]
+    }
+    failure {
+      script {
+        if (env.CLEAN_UP == "true") {
+          ansibleTower \
+            towerServer: 'tower',
+            templateType: 'job',
+            jobTemplate: '16',  // devnet-archive-logs
+            jobType: 'run',
+            extraVars: """devnet: ${params.NETWORK}""",
+            throwExceptionWhenFail: false,
+            verbose: false
+        }
+      }
+      liskSlackSend('danger', "Build failed (<${env.BUILD_URL}/console|console>, <${env.BUILD_URL}/changes|changes>)", 'lisk-ci-core')
+    }
+    cleanup {
+      script {
+        if (env.CLEAN_UP == "true") {
+          ansibleTower \
+            towerServer: 'tower',
+            templateType: 'job',
+            jobTemplate: '15',  // do-destroy-tag
+            jobType: 'run',
+            extraVars: """do_tag: ${params.NETWORK}_node""",
+            throwExceptionWhenFail: false,
+            verbose: false
+        } else {
+          echo 'Not cleaning up, as requested.'
+        }
+      }
+    }
+  }
+}
+// vim: filetype=groovy


### PR DESCRIPTION
### What was the problem?
Currently, the default Jenkins job builds the Lisk Core and Create a network and run tests. The job holds the queue until is completed, and it will block users testing parallelly
### How did I fix it?
In order to allow developers to use the network creation and running the tests independently, avoid waiting time for tests to complete and allow users to create a network quickly and run tests from local or using Jenkins.
### How to test it?
- Once Jenkins job configured and tested we can merge this PR
### Review checklist

* The PR resolves #103 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
