### PR TITLE
Put variable in curly braces so that it gets expanded as expected - Closes #119

### DIFF
--- a/qa/Jenkinsfile
+++ b/qa/Jenkinsfile
@@ -4,7 +4,7 @@ properties([
   parameters([
     string(name: 'SDK_BRANCH_NAME', defaultValue: 'development', description: 'Lisk core branch name', ),
     string(name: 'CORE_BRANCH_NAME', defaultValue: 'master', description: 'Lisk core branch name', ),
-    string(name: 'NETWORK', defaultValue: 'jenkinsnet-$BUILD_ID', description: 'To Run test against a network', ),
+    string(name: 'NETWORK', defaultValue: 'jenkinsnet-${BUILD_ID}', description: 'To Run test against a network', ),
     string(name: 'NODES_PER_REGION', defaultValue: '1', description: 'Number of nodes per region', ),
     string(name: 'STRESS_COUNT', defaultValue: '500', description: 'Number of transactions to create', ), // Used by stage: Test Network Stress
     string(name: 'NEWRELIC_ENABLED', defaultValue: 'no', description: 'Enable NewRelic', ),


### PR DESCRIPTION
### What was the problem?
The default value for the `NETWORK` parameter container a variable without braces: it did not expand as expected in some case (e.g. `"foo: ${params.NETWORK}_bar"`).

### How did I fix it?
The variable in the default value is now enclosed in curly braces.

### How to test it?
Run the Jenkins [job](https://jenkins.lisk.io/job/lisk-qa/job/lisk-core-qa/job/lisk-core-qa-fix-destroy-network/) with the default value for the `NETWORK` parameter.

### Review checklist

* The PR resolves #119 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
