### PR TITLE
Add "logs" make target for docker - Closes #96

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -33,8 +33,10 @@ coldstart: $(lisk_net)_blockchain.db.gz up
 clean:
 	rm -f *blockchain.db.gz
 
+LOGS_TAIL_LINES?=1000
+LOGS_BUNYAN_OPTIONS=-o short
 logs:
-	docker-compose logs --tail=1000 --follow lisk |docker-compose exec -T lisk npx bunyan
+	docker-compose logs --tail=$(LOGS_TAIL_LINES) --follow lisk |docker-compose exec -T lisk npx bunyan $(LOGS_BUNYAN_OPTIONS)
 
 mrproper: clean
 	docker-compose down --volumes --remove-orphans

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -36,7 +36,7 @@ clean:
 LOGS_TAIL_LINES?=1000
 LOGS_BUNYAN_OPTIONS=-o short
 logs:
-	docker-compose logs --tail=$(LOGS_TAIL_LINES) --follow lisk |docker-compose exec -T lisk npx bunyan $(LOGS_BUNYAN_OPTIONS)
+	docker logs --tail=$(LOGS_TAIL_LINES) --follow $$( docker-compose ps --quiet lisk ) |docker-compose exec -T lisk npx bunyan $(LOGS_BUNYAN_OPTIONS)
 
 mrproper: clean
 	docker-compose down --volumes --remove-orphans

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -33,5 +33,8 @@ coldstart: $(lisk_net)_blockchain.db.gz up
 clean:
 	rm -f *blockchain.db.gz
 
+logs:
+	docker-compose logs --tail=1000 --follow lisk |docker-compose exec -T lisk npx bunyan
+
 mrproper: clean
 	docker-compose down --volumes --remove-orphans


### PR DESCRIPTION
### What was the problem?
A `logs` make target was requested in #96 

### How did I fix it?
Added `logs` make target in `docker/Makefile`

### How to test it?
```
cd docker/
cp .env.development .env
make
make logs
make logs LOGS_TAIL_LINES=10
make logs LOGS_TAIL_LINES=all
make logs LOGS_TAIL_LINES=100 LOGS_BUNYAN_OPTIONS=
make logs LOGS_BUNYAN_OPTIONS="-o long"
```

### Review checklist

* The PR resolves #96 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
