### PR TITLE
Call 'lisk' instead of 'lisky' - Closes #136

### DIFF
--- a/build/target/lisk.sh
+++ b/build/target/lisk.sh
@@ -499,8 +499,8 @@ case $1 in
 "logs")
 	tail_logs
 	;;
-"lisky")
-	lisky
+"lisky|lisk|commander")
+	lisk
 	;;
 "help")
 	help
@@ -508,7 +508,7 @@ case $1 in
 *)
 	echo "Error: Unrecognized command."
 	echo ""
-	echo "Available commands are: start stop start_node stop_node start_db stop_db reload rebuild coldstart logs lisky status help"
+	echo "Available commands are: start stop start_node stop_node start_db stop_db reload rebuild coldstart logs <lisky|lisk|commander> status or help"
 	help
 	;;
 esac


### PR DESCRIPTION
### What was the problem?
`lisky` was being called while the binary is now called `lisk`

### How did I fix it?
Accept all of `lisky`, `lisk` and `commander` as commands and call `lisk`.

### How to test it?
Run `./lisk.sh <lisky|lisk|commander>`

### Review checklist

* The PR resolves #136 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
