### PR TITLE
Add core version number to snapshot file name - Closes #140

### DIFF
--- a/build/target/lisk_snapshot.sh
+++ b/build/target/lisk_snapshot.sh
@@ -38,6 +38,7 @@ cd "$( cd -P -- "$(dirname -- "$0")" && pwd -P )" || exit 2
 # shellcheck source=env.sh
 source "$( pwd )/env.sh"
 
+CORE_VERSION=$( jq --raw-output .version package.json )
 OUTPUT_DIRECTORY="${OUTPUT_DIRECTORY:-$PWD/backups}"
 SOURCE_DATABASE=$( node scripts/generate_config.js |jq --raw-output '.components.storage.database' )
 
@@ -62,7 +63,7 @@ bash lisk.sh start_node >/dev/null
 psql --dbname=lisk_snapshot --command='TRUNCATE peers;' >/dev/null
 
 HEIGHT=$( psql --dbname=lisk_snapshot --tuples-only --command='SELECT height FROM blocks ORDER BY height DESC LIMIT 1;' |xargs)
-OUTPUT_FILE="${OUTPUT_DIRECTORY}/${SOURCE_DATABASE}_backup-${HEIGHT}.gz"
+OUTPUT_FILE="${OUTPUT_DIRECTORY}/${SOURCE_DATABASE}_backup-${HEIGHT}-${CORE_VERSION}.gz"
 
 pg_dump --no-owner lisk_snapshot |gzip -9 >"$TEMP_FILE"
 mv "$TEMP_FILE" "$OUTPUT_FILE"


### PR DESCRIPTION
### What was the problem?
Snapshot file name did not contain core version; there was no way to know which core version the snapshot had been created from. 

### How did I fix it?
- get core version from `package.json`
- suffix the snapshot file name with core version

### How to test it?
Run `lisk_snapshot.sh`, ensure the created snapshot file is named `lisk_<NET>_backup-<BLOCKS>-<VERSION>.gz`.

### Review checklist

* The PR resolves #140 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
