### PR TITLE
Update dapp txs to use latest schema - Closes #147, #93

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,6 @@
 	},
 	"dependencies": {
 		"@liskhq/bignum": "1.3.1",
-		"@liskhq/lisk-cryptography": "2.3.0",
-		"@liskhq/lisk-transactions": "3.0.0-alpha.0",
 		"async": "2.6.1",
 		"bluebird": "3.5.3",
 		"commander": "2.19.0",

--- a/src/transactions/7_out_transfer_transaction.ts
+++ b/src/transactions/7_out_transfer_transaction.ts
@@ -13,18 +13,19 @@
  *
  */
 import BigNum from '@liskhq/bignum';
-import {
-	BaseTransaction,
+import { transactions, cryptography } from 'lisk-sdk';
+const {
 	convertToAssetError,
-	StateStore,
-	StateStorePrepare,
 	TransactionError,
-	TransactionJSON,
-	utils,
-} from '@liskhq/lisk-transactions';
+	utils: {
+		validator,
+		verifyAmountBalance,
+		isValidInteger,
+	},
+	constants,
+} = transactions;
 import { MAX_TRANSACTION_AMOUNT, OUT_TRANSFER_FEE } from './constants';
 
-const { verifyAmountBalance, validator } = utils;
 const TRANSACTION_DAPP_REGISTERATION_TYPE = 5;
 
 export interface OutTransferAsset {
@@ -55,23 +56,29 @@ export const outTransferAssetFormatSchema = {
 	},
 };
 
-export class OutTransferTransaction extends BaseTransaction {
+export class OutTransferTransaction extends transactions.BaseTransaction {
 	public readonly asset: OutTransferAsset;
 	public readonly containsUniqueData: boolean;
 	public static TYPE = 7;
 	public static FEE = OUT_TRANSFER_FEE.toString();
+	public amount: BigNum;
+	public recipientId: string;
 
 	public constructor(rawTransaction: unknown) {
 		super(rawTransaction);
 		const tx = (typeof rawTransaction === 'object' && rawTransaction !== null
 			? rawTransaction
-			: {}) as Partial<TransactionJSON>;
+			: {}) as Partial<transactions.TransactionJSON>;
+
+		// TransactionJSON no longer has amount, so need to access this way
+		this.amount = new BigNum(tx['amount'] || '0');
+		this.recipientId = tx['recipientId'] || '';
 
 		this.asset = (tx.asset || { outTransfer: {} }) as OutTransferAsset;
 		this.containsUniqueData = true;
 	}
 
-	public async prepare(store: StateStorePrepare): Promise<void> {
+	public async prepare(store: transactions.StateStorePrepare): Promise<void> {
 		await store.account.cache([
 			{
 				address: this.senderId,
@@ -87,12 +94,41 @@ export class OutTransferTransaction extends BaseTransaction {
 		]);
 	}
 
-	protected assetToBytes(): Buffer {
+	// Function getBasicBytes is overriden to maintain the bytes order
+	// TODO: remove after hardfork implementation
+	protected getBasicBytes(): Buffer {
+		const transactionType = cryptography.intToBuffer(this.type, constants.BYTESIZES.TYPE);
+		const transactionTimestamp = cryptography.intToBuffer(
+			this.timestamp,
+			constants.BYTESIZES.TIMESTAMP,
+			'little',
+		);
+
+		const transactionSenderPublicKey = cryptography.hexToBuffer(this.senderPublicKey);
+
+		const transactionRecipientID = cryptography.intToBuffer(
+			this.recipientId.slice(0, -1),
+			constants.BYTESIZES.RECIPIENT_ID,
+		).slice(0, constants.BYTESIZES.RECIPIENT_ID);
+
+		const transactionAmount = cryptography.bigNumberToBuffer(
+			this.amount.toString(),
+			constants.BYTESIZES.AMOUNT,
+			'little',
+		);
+
 		const { dappId, transactionId } = this.asset.outTransfer;
 		const outAppIdBuffer = Buffer.from(dappId, 'utf8');
 		const outTransactionIdBuffer = Buffer.from(transactionId, 'utf8');
 
-		return Buffer.concat([outAppIdBuffer, outTransactionIdBuffer]);
+		return Buffer.concat([
+			transactionType,
+			transactionTimestamp,
+			transactionSenderPublicKey,
+			transactionRecipientID,
+			transactionAmount,
+			Buffer.concat([outAppIdBuffer, outTransactionIdBuffer]),
+		]);
 	}
 
 	public assetToJSON(): object {
@@ -100,8 +136,8 @@ export class OutTransferTransaction extends BaseTransaction {
 	}
 
 	protected verifyAgainstTransactions(
-		transactions: ReadonlyArray<TransactionJSON>
-	): ReadonlyArray<TransactionError> {
+		transactions: ReadonlyArray<transactions.TransactionJSON>
+	): ReadonlyArray<transactions.TransactionError> {
 		const sameTypeTransactions = transactions.filter(
 			tx =>
 				tx.type === OutTransferTransaction.TYPE &&
@@ -121,12 +157,12 @@ export class OutTransferTransaction extends BaseTransaction {
 			: [];
 	}
 
-	protected validateAsset(): ReadonlyArray<TransactionError> {
+	protected validateAsset(): ReadonlyArray<transactions.TransactionError> {
 		validator.validate(outTransferAssetFormatSchema, this.asset);
 		const errors = convertToAssetError(
 			this.id,
 			validator.errors
-		) as TransactionError[];
+		) as transactions.TransactionError[];
 
 		// Amount has to be greater than 0
 		if (this.amount.lte(0)) {
@@ -154,8 +190,8 @@ export class OutTransferTransaction extends BaseTransaction {
 		return errors;
 	}
 
-	protected applyAsset(store: StateStore): ReadonlyArray<TransactionError> {
-		const errors: TransactionError[] = [];
+	protected applyAsset(store: transactions.StateStore): ReadonlyArray<transactions.TransactionError> {
+		const errors: transactions.TransactionError[] = [];
 		const dappRegistrationTransaction = store.transaction.get(
 			this.asset.outTransfer.dappId
 		);
@@ -210,8 +246,8 @@ export class OutTransferTransaction extends BaseTransaction {
 		return errors;
 	}
 
-	public undoAsset(store: StateStore): ReadonlyArray<TransactionError> {
-		const errors: TransactionError[] = [];
+	public undoAsset(store: transactions.StateStore): ReadonlyArray<transactions.TransactionError> {
+		const errors: transactions.TransactionError[] = [];
 		const sender = store.account.get(this.senderId);
 		const updatedBalance = new BigNum(sender.balance).add(this.amount);
 

--- a/src/transactions/7_out_transfer_transaction.ts
+++ b/src/transactions/7_out_transfer_transaction.ts
@@ -20,7 +20,6 @@ const {
 	utils: {
 		validator,
 		verifyAmountBalance,
-		isValidInteger,
 	},
 	constants,
 } = transactions;

--- a/src/transactions/constants.ts
+++ b/src/transactions/constants.ts
@@ -13,9 +13,9 @@
  *
  */
 /* tslint:disable:no-magic-numbers */
-import { constants } from '@liskhq/lisk-transactions';
+import { transactions } from 'lisk-sdk';
 
-const { FIXED_POINT, MAX_TRANSACTION_AMOUNT } = constants;
+const { FIXED_POINT, MAX_TRANSACTION_AMOUNT } = transactions.constants;
 
 export const TRANSACTION_DAPP_TYPE = 5;
 


### PR DESCRIPTION
### What was the problem?
Transaction schema was outdated, and it needed to be updated

### How did I fix it?
- Update the schema definition and usage according to the new schema
- Updated package.json to remove transaction library and cryptography library

### How to test it?
Link the lisk-core locally with latest development branch, and check if it builds.

### Review checklist

* The PR resolves #147, #93 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
