### PR TITLE
Error when validating OutTransferTransaction - Closes #164

### DIFF
--- a/src/transactions/6_in_transfer_transaction.ts
+++ b/src/transactions/6_in_transfer_transaction.ts
@@ -27,6 +27,7 @@ const {
 	TransactionError,
 	utils: {
 		convertBeddowsToLSK,
+		isValidNumber,
 		verifyAmountBalance,
 		validator,
 	},
@@ -56,6 +57,13 @@ export const inTransferAssetFormatSchema = {
 	},
 };
 
+interface RawAsset {
+	readonly amount: BigNum;
+	readonly inTransfer: {
+		readonly dappId: string;
+	};
+}
+
 export class InTransferTransaction extends BaseTransaction {
 	public readonly asset: InTransferAsset;
 	public static TYPE = 6;
@@ -67,11 +75,12 @@ export class InTransferTransaction extends BaseTransaction {
 		const tx = (typeof rawTransaction === 'object' && rawTransaction !== null
 			? rawTransaction
 			: {}) as Partial<transactions.TransactionJSON>;
-		
-		// TransactionJSON no longer has amount, so need to access this way
-		this.amount = new BigNum(tx['amount'] || '0');
 
-		this.asset = (tx.asset || { inTransfer: {} }) as InTransferAsset;
+		const rawAsset = tx.asset as RawAsset;
+		this.asset = {
+			inTransfer: rawAsset.inTransfer || {},
+		} as InTransferAsset;
+		this.amount = new BigNum(isValidNumber(rawAsset.amount) ? rawAsset.amount : '0');
 	}
 
 	// Function getBasicBytes is overriden to maintain the bytes order

--- a/src/transactions/7_out_transfer_transaction.ts
+++ b/src/transactions/7_out_transfer_transaction.ts
@@ -23,6 +23,7 @@ const {
 	convertToAssetError,
 	TransactionError,
 	utils: {
+		isValidNumber,
 		validator,
 		verifyAmountBalance,
 	},
@@ -58,6 +59,15 @@ export const outTransferAssetFormatSchema = {
 	},
 };
 
+interface RawAsset {
+	readonly recipientId: string;
+	readonly amount: BigNum;
+	readonly outTransfer: {
+		readonly dappId: string;
+		readonly transactionId: string;
+	};
+}
+
 export class OutTransferTransaction extends BaseTransaction {
 	public readonly asset: OutTransferAsset;
 	public readonly containsUniqueData: boolean;
@@ -72,11 +82,13 @@ export class OutTransferTransaction extends BaseTransaction {
 			? rawTransaction
 			: {}) as Partial<transactions.TransactionJSON>;
 
-		// TransactionJSON no longer has amount, so need to access this way
-		this.amount = new BigNum(tx['amount'] || '0');
-		this.recipientId = tx['recipientId'] || '';
+		const rawAsset = tx.asset as RawAsset;
+		this.asset = {
+			outTransfer: rawAsset.outTransfer || {},
+		} as OutTransferAsset;
+		this.amount = new BigNum(isValidNumber(rawAsset.amount) ? rawAsset.amount : '0');
+		this.recipientId = rawAsset.recipientId || '';
 
-		this.asset = (tx.asset || { outTransfer: {} }) as OutTransferAsset;
 		this.containsUniqueData = true;
 	}
 


### PR DESCRIPTION
### What was the problem?
Dapp transfer transactions was not parsing `amount` and `recipientId` corretly

### How did I fix it?
First by fixing the Storage component in Lisk SDK (https://github.com/LiskHQ/lisk-sdk/issues/4547) and then adjusting `InTransferTransaction` and `OutTransferTransaction` to parse the data correctly.

### How to test it?
Start snapshoting process
It should pass height 808831

### Review checklist

* The PR resolves #164
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
