### PR TITLE
Update to use lisk-validator instead of transaction/validator - Closes #169

### DIFF
--- a/src/transactions/1_second_signature_transaction.ts
+++ b/src/transactions/1_second_signature_transaction.ts
@@ -15,6 +15,7 @@
 import {
 	transactions,
 	cryptography,
+	validator as liskValidator,
 } from 'lisk-sdk';
 import {
 	BaseTransaction,
@@ -24,7 +25,6 @@ const {
 	convertToAssetError,
 	TransactionError,
 	utils: {
-		validator,
 		getId,
 	},
 	constants: {
@@ -36,6 +36,9 @@ const {
 	hexToBuffer,
 	signData,
 } = cryptography;
+const {
+	validator,
+} = liskValidator;
 
 export interface SecondSignatureAsset {
 	readonly publicKey: string;
@@ -99,10 +102,10 @@ export class SecondSignatureTransaction extends BaseTransaction {
 	}
 
 	protected validateAsset(): ReadonlyArray<transactions.TransactionError> {
-		validator.validate(secondSignatureAssetFormatSchema, this.asset);
+		const schemaerrors = validator.validate(secondSignatureAssetFormatSchema, this.asset);
 		const errors = convertToAssetError(
 			this.id,
-			validator.errors,
+			schemaerrors,
 		) as transactions.TransactionError[];
 
 		return errors;

--- a/src/transactions/2_delegate_transaction.ts
+++ b/src/transactions/2_delegate_transaction.ts
@@ -14,6 +14,7 @@
  */
 import {
 	transactions,
+	validator as liskValidator,
 } from 'lisk-sdk';
 import {
 	BaseTransaction,
@@ -22,13 +23,13 @@ import {
 const {
 	convertToAssetError,
 	TransactionError,
-	utils: {
-		validator,
-	},
 	constants: {
 		DELEGATE_FEE,
 	},
 } = transactions;
+const {
+	validator,
+} = liskValidator;
 
 
 export interface DelegateAsset {
@@ -99,10 +100,10 @@ export class DelegateTransaction extends BaseTransaction {
 	}
 
 	protected validateAsset(): ReadonlyArray<transactions.TransactionError> {
-		validator.validate(delegateAssetFormatSchema, this.asset);
+		const schemaErrors = validator.validate(delegateAssetFormatSchema, this.asset);
 		const errors = convertToAssetError(
 			this.id,
-			validator.errors,
+			schemaErrors,
 		) as transactions.TransactionError[];
 
 		return errors;

--- a/src/transactions/3_vote_transaction.ts
+++ b/src/transactions/3_vote_transaction.ts
@@ -16,6 +16,7 @@ import BigNum from '@liskhq/bignum';
 import {
 	transactions,
 	cryptography,
+	validator as liskValidator,
 } from 'lisk-sdk';
 import {
 	BaseTransaction,
@@ -25,9 +26,7 @@ const {
 	convertToAssetError,
 	TransactionError,
 	utils: {
-		validator,
 		verifyAmountBalance,
-		isValidNumber,
 	},
 	constants: {
 		BYTESIZES,
@@ -41,6 +40,10 @@ const {
 	intToBuffer,
 	stringToBuffer,
 } = cryptography;
+const {
+	isPositiveNumberString,
+	validator,
+} = liskValidator;
 
 const PREFIX_UPVOTE = '+';
 const PREFIX_UNVOTE = '-';
@@ -111,7 +114,7 @@ export class VoteTransaction extends BaseTransaction {
 				votes: rawAsset.votes,
 				recipientId: rawAsset.recipientId || this.senderId,
 				amount: new BigNum(
-					isValidNumber(rawAsset.amount) ? rawAsset.amount : '0',
+					isPositiveNumberString(rawAsset.amount) ? rawAsset.amount : '0',
 				),
 			};
 		} else {
@@ -221,10 +224,10 @@ export class VoteTransaction extends BaseTransaction {
 
 	protected validateAsset(): ReadonlyArray<transactions.TransactionError> {
 		const asset = this.assetToJSON();
-		validator.validate(voteAssetFormatSchema, asset);
+		const schemaErrors = validator.validate(voteAssetFormatSchema, asset);
 		const errors = convertToAssetError(
 			this.id,
-			validator.errors,
+			schemaErrors,
 		) as transactions.TransactionError[];
 
 		return errors;

--- a/src/transactions/4_multisignature_transaction.ts
+++ b/src/transactions/4_multisignature_transaction.ts
@@ -16,6 +16,7 @@ import BigNum from '@liskhq/bignum';
 import {
 	transactions,
 	cryptography,
+	validator as liskValidator,
 } from 'lisk-sdk';
 import {
 	BaseTransaction,
@@ -29,7 +30,6 @@ const {
 	createResponse,
 	Status,
 	utils: {
-		validator,
 		validateMultisignatures,
 		validateSignature,
 	},
@@ -40,6 +40,9 @@ const {
 const {
 	getAddressFromPublicKey,
 } = cryptography;
+const {
+	validator,
+} = liskValidator;
 
 export const multisignatureAssetFormatSchema = {
 	type: 'object',
@@ -156,10 +159,10 @@ export class MultisignatureTransaction extends BaseTransaction {
 	}
 
 	protected validateAsset(): ReadonlyArray<transactions.TransactionError> {
-		validator.validate(multisignatureAssetFormatSchema, this.asset);
+		const schemaErrors = validator.validate(multisignatureAssetFormatSchema, this.asset);
 		const errors = convertToAssetError(
 			this.id,
-			validator.errors,
+			schemaErrors,
 		) as transactions.TransactionError[];
 
 		if (errors.length > 0) {

--- a/src/transactions/5_dapp_transaction.ts
+++ b/src/transactions/5_dapp_transaction.ts
@@ -14,6 +14,7 @@
  */
 import {
 	transactions,
+	validator as liskValidator,
 } from 'lisk-sdk';
 import {
 	BaseTransaction,
@@ -23,11 +24,11 @@ import { DAPP_FEE } from './constants';
 const {
 	convertToAssetError,
 	TransactionError,
-	utils: {
-		validator,
-		stringEndsWith,
-	},
 } = transactions;
+const {
+	validator,
+	isStringEndsWith,
+} = liskValidator;
 
 export interface DappAsset {
 	readonly dapp: {
@@ -214,10 +215,10 @@ export class DappTransaction extends BaseTransaction {
 	}
 
 	protected validateAsset(): ReadonlyArray<transactions.TransactionError> {
-		validator.validate(dappAssetFormatSchema, this.asset);
+		const schemaErrors = validator.validate(dappAssetFormatSchema, this.asset);
 		const errors = convertToAssetError(
 			this.id,
-			validator.errors
+			schemaErrors,	
 		) as transactions.TransactionError[];
 
 		const validLinkSuffix = ['.zip'];
@@ -228,7 +229,7 @@ export class DappTransaction extends BaseTransaction {
 
 		if (
 			this.asset.dapp.link &&
-			!stringEndsWith(this.asset.dapp.link, validLinkSuffix)
+			!isStringEndsWith(this.asset.dapp.link, validLinkSuffix)
 		) {
 			errors.push(
 				new TransactionError(
@@ -243,7 +244,7 @@ export class DappTransaction extends BaseTransaction {
 		const validIconSuffix = ['.png', '.jpeg', '.jpg'];
 		if (
 			this.asset.dapp.icon &&
-			!stringEndsWith(this.asset.dapp.icon, validIconSuffix)
+			!isStringEndsWith(this.asset.dapp.icon, validIconSuffix)
 		) {
 			errors.push(
 				new TransactionError(

--- a/src/transactions/7_out_transfer_transaction.ts
+++ b/src/transactions/7_out_transfer_transaction.ts
@@ -13,7 +13,7 @@
  *
  */
 import BigNum from '@liskhq/bignum';
-import { transactions, cryptography } from 'lisk-sdk';
+import { transactions, cryptography, validator as liskValidator } from 'lisk-sdk';
 import {
 	BaseTransaction,
 } from './legacy_base_transaction';
@@ -23,12 +23,14 @@ const {
 	convertToAssetError,
 	TransactionError,
 	utils: {
-		isValidNumber,
-		validator,
 		verifyAmountBalance,
 	},
 	constants,
 } = transactions;
+const {
+	isPositiveNumberString,
+	validator,
+} = liskValidator;
 const TRANSACTION_DAPP_REGISTERATION_TYPE = 5;
 
 export interface OutTransferAsset {
@@ -92,7 +94,7 @@ export class OutTransferTransaction extends BaseTransaction {
 
 		const rawAsset = tx.asset as RawAsset;
 		this.asset = {
-			amount: new BigNum(isValidNumber(rawAsset.amount) ? rawAsset.amount : '0'),
+			amount: new BigNum(isPositiveNumberString(rawAsset.amount) ? rawAsset.amount : '0'),
 			recipientId: rawAsset.recipientId || '',
 			outTransfer: rawAsset.outTransfer || {},
 		} as OutTransferAsset;
@@ -180,10 +182,10 @@ export class OutTransferTransaction extends BaseTransaction {
 	}
 
 	protected validateAsset(): ReadonlyArray<transactions.TransactionError> {
-		validator.validate(outTransferAssetFormatSchema, this.asset);
+		const schemaErrors = validator.validate(outTransferAssetFormatSchema, this.asset);
 		const errors = convertToAssetError(
 			this.id,
-			validator.errors
+			schemaErrors
 		) as transactions.TransactionError[];
 
 		// Amount has to be greater than 0

--- a/src/transactions/legacy_base_transaction.ts
+++ b/src/transactions/legacy_base_transaction.ts
@@ -16,6 +16,7 @@ import BigNum from '@liskhq/bignum';
 import {
 	transactions,
 	cryptography,
+	validator as liskValidator,
 } from 'lisk-sdk';
 import * as schemas from './schema';
 
@@ -29,7 +30,6 @@ const {
 		getId,
 		validateSenderIdAndPublicKey,
 		validateSignature,
-		validator,
 		verifyBalance,
 		verifyMultiSignatures,
 		verifySecondSignature,
@@ -42,6 +42,9 @@ const {
 		UNCONFIRMED_TRANSACTION_TIMEOUT,
 	},
 } = transactions;
+const {
+	validator,
+} = liskValidator;
 const {
 	getAddressAndPublicKeyFromPassphrase,
 	getAddressFromPublicKey,
@@ -541,10 +544,10 @@ export abstract class BaseTransaction {
 
 	private _validateSchema(): ReadonlyArray<transactions.TransactionError> {
 		const transaction = this.toJSON();
-		validator.validate(schemas.baseTransaction, transaction);
+		const schemaErrors = validator.validate(schemas.baseTransaction, transaction);
 		const errors = convertToTransactionError(
 			this.id,
-			validator.errors,
+			schemaErrors,
 		) as transactions.TransactionError[];
 
 		if (


### PR DESCRIPTION
### What was the problem?
After https://github.com/LiskHQ/lisk-sdk/pull/4574, the build will fail since the validator in the transaction is removed.

### How did I fix it?
Instead of validator in the transactions, it uses validator in SDK (which comes from lisk-validator)

### How to test it?
- It should build correctly

### Review checklist

* The PR resolves #169 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
