### PR TITLE
Schema validation error for tx type 7 - Closes #174

### DIFF
--- a/src/transactions/6_in_transfer_transaction.ts
+++ b/src/transactions/6_in_transfer_transaction.ts
@@ -145,7 +145,10 @@ export class InTransferTransaction extends BaseTransaction {
 	}
 
 	public assetToJSON(): object {
-		return this.asset;
+		return {
+			amount: this.asset.amount.toString(),
+			inTransfer: this.asset.inTransfer,
+		};
 	}
 
 	// tslint:disable-next-line prefer-function-over-method
@@ -156,7 +159,8 @@ export class InTransferTransaction extends BaseTransaction {
 	}
 
 	protected validateAsset(): ReadonlyArray<transactions.TransactionError> {
-		const schemaErrors = validator.validate(inTransferAssetFormatSchema, this.asset);
+		const asset = this.assetToJSON();
+		const schemaErrors = validator.validate(inTransferAssetFormatSchema, asset);
 		const errors = convertToAssetError(
 			this.id,
 			schemaErrors,

--- a/src/transactions/6_in_transfer_transaction.ts
+++ b/src/transactions/6_in_transfer_transaction.ts
@@ -146,8 +146,8 @@ export class InTransferTransaction extends BaseTransaction {
 
 	public assetToJSON(): object {
 		return {
+			...this.asset,
 			amount: this.asset.amount.toString(),
-			inTransfer: this.asset.inTransfer,
 		};
 	}
 

--- a/src/transactions/7_out_transfer_transaction.ts
+++ b/src/transactions/7_out_transfer_transaction.ts
@@ -156,7 +156,11 @@ export class OutTransferTransaction extends BaseTransaction {
 	}
 
 	public assetToJSON(): object {
-		return this.asset;
+		return {
+			amount: this.asset.amount.toString(),
+			recipientId: this.asset.recipientId,
+			outTransfer: this.asset.outTransfer,
+		};
 	}
 
 	protected verifyAgainstTransactions(
@@ -182,7 +186,8 @@ export class OutTransferTransaction extends BaseTransaction {
 	}
 
 	protected validateAsset(): ReadonlyArray<transactions.TransactionError> {
-		const schemaErrors = validator.validate(outTransferAssetFormatSchema, this.asset);
+		const asset = this.assetToJSON();
+		const schemaErrors = validator.validate(outTransferAssetFormatSchema, asset);
 		const errors = convertToAssetError(
 			this.id,
 			schemaErrors

--- a/src/transactions/7_out_transfer_transaction.ts
+++ b/src/transactions/7_out_transfer_transaction.ts
@@ -157,9 +157,8 @@ export class OutTransferTransaction extends BaseTransaction {
 
 	public assetToJSON(): object {
 		return {
+			...this.asset,
 			amount: this.asset.amount.toString(),
-			recipientId: this.asset.recipientId,
-			outTransfer: this.asset.outTransfer,
 		};
 	}
 


### PR DESCRIPTION
### What was the problem?
`InTransferTransaction` and `OutTransferTransaction` expect asset.amount to be string but the conversion was missing from `assetToJSON` method similar to how it's done for `TransferTransaction`

### How did I fix it?
By converting `amount` to string inside `assetToJSON` for both `InTransferTransaction` and `OutTransferTransaction`

### How to test it?
Start syncing with mainnet. It should pass block height `808831`

### Review checklist

* The PR resolves #174
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
