### PR TITLE
Fix loadash vulnerability - Closes #184

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10535,9 +10535,9 @@
 			}
 		},
 		"lodash": {
-			"version": "4.17.14",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-			"integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
+			"version": "4.17.15",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
 		},
 		"lodash.clonedeep": {
 			"version": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 		"deep-diff": "1.0.2",
 		"lisk-commander": "3.0.0-alpha.2",
 		"lisk-sdk": "3.0.0-alpha.2",
-		"lodash": "4.17.14",
+		"lodash": "4.17.15",
 		"moment": "2.23.0",
 		"pm2": "3.5.0",
 		"semver": "5.6.0",


### PR DESCRIPTION
### What was the problem?
https://github.com/lodash/lodash/pull/4336
### How did I solve it?
Updating the lodash version 
### How to test it?
`npm audit`

### Review checklist

* The PR resolves #184 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
