### PR TITLE
Lisk Snapshot script have inconsistent state with the SDK - Closes #193

### DIFF
--- a/build/target/lisk_snapshot.sh
+++ b/build/target/lisk_snapshot.sh
@@ -60,7 +60,7 @@ bash lisk.sh start_node >/dev/null
 
 # The dump file produced by pg_dump does not contain the statistics used by the optimizer to make query planning decisions.
 #vacuumdb --analyze --full lisk_snapshot
-psql --dbname=lisk_snapshot --command='TRUNCATE peers;' >/dev/null
+psql --dbname=lisk_snapshot --command='TRUNCATE network_info, forger_info, temp_blocks;' >/dev/null
 
 HEIGHT=$( psql --dbname=lisk_snapshot --tuples-only --command='SELECT height FROM blocks ORDER BY height DESC LIMIT 1;' |xargs)
 OUTPUT_FILE="${OUTPUT_DIRECTORY}/${SOURCE_DATABASE}_backup-${HEIGHT}-${CORE_VERSION}.gz"


### PR DESCRIPTION
### What was the problem?

The list of tables to truncate during the snapshot was not consistent with SDK. 

### How did I fix it?

Updated the list of tables to truncate. 

### How to test it?

- Start node from scratch
- Run the snapshot script.
- Ensure snapshot has been created. 

### Review checklist

* The PR resolves #193
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
