### PR TITLE
Rebuild and snapshot create different file extensions - Closes #194

### DIFF
--- a/build/target/lisk.sh
+++ b/build/target/lisk.sh
@@ -402,7 +402,7 @@ help() {
 	echo -e "stop_node                             Stops a Nodejs process for Lisk"
 	echo -e "stop                                  Stop the Nodejs process and PostgreSQL Database for Lisk"
 	echo -e "reload                                Restarts the Nodejs process for Lisk"
-	echo -e "rebuild [-u URL] [-f file.db.gz] [-0] Rebuilds the PostgreSQL database"
+	echo -e "rebuild [-u URL] [-f file.gz] [-0] Rebuilds the PostgreSQL database"
 	echo -e "start_db                              Starts the PostgreSQL database"
 	echo -e "stop_db                               Stops the PostgreSQL database"
 	echo -e "coldstart                             Creates the PostgreSQL database and configures config.json for Lisk"

--- a/build/target/lisk_snapshot.sh
+++ b/build/target/lisk_snapshot.sh
@@ -63,7 +63,7 @@ bash lisk.sh start_node >/dev/null
 psql --dbname=lisk_snapshot --command='TRUNCATE peers;' >/dev/null
 
 HEIGHT=$( psql --dbname=lisk_snapshot --tuples-only --command='SELECT height FROM blocks ORDER BY height DESC LIMIT 1;' |xargs)
-OUTPUT_FILE="${OUTPUT_DIRECTORY}/${SOURCE_DATABASE}_backup-${HEIGHT}-${CORE_VERSION}.gz"
+OUTPUT_FILE="${OUTPUT_DIRECTORY}/${SOURCE_DATABASE}_backup-${HEIGHT}-${CORE_VERSION}.db.gz"
 
 pg_dump --no-owner lisk_snapshot |gzip -9 >"$TEMP_FILE"
 mv "$TEMP_FILE" "$OUTPUT_FILE"

--- a/build/target/lisk_snapshot.sh
+++ b/build/target/lisk_snapshot.sh
@@ -63,7 +63,7 @@ bash lisk.sh start_node >/dev/null
 psql --dbname=lisk_snapshot --command='TRUNCATE peers;' >/dev/null
 
 HEIGHT=$( psql --dbname=lisk_snapshot --tuples-only --command='SELECT height FROM blocks ORDER BY height DESC LIMIT 1;' |xargs)
-OUTPUT_FILE="${OUTPUT_DIRECTORY}/${SOURCE_DATABASE}_backup-${HEIGHT}-${CORE_VERSION}.db.gz"
+OUTPUT_FILE="${OUTPUT_DIRECTORY}/${SOURCE_DATABASE}_backup-${HEIGHT}-${CORE_VERSION}.gz"
 
 pg_dump --no-owner lisk_snapshot |gzip -9 >"$TEMP_FILE"
 mv "$TEMP_FILE" "$OUTPUT_FILE"


### PR DESCRIPTION
### What was the problem?

The extension name for the output during the snapshot was different than the what was documented for rebuild step. 

### How did I fix it?

Fixed the name in the script help function. 

### Review checklist

* The PR resolves #194
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
