### PR TITLE
Set base Docker image to node:10-alpine3.9 - Closes #202

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10-alpine AS builder
+FROM node:10-alpine3.9 AS builder
 
 ARG REGISTRY_URL
 ARG REGISTRY_AUTH_TOKEN
@@ -24,7 +24,7 @@ RUN npm ci --production && \
     date --utc "+%Y-%m-%dT%H:%M:%S.000Z" >.build
 
 
-FROM node:10-alpine
+FROM node:10-alpine3.9
 
 ENV NODE_ENV=production
 ENV WFI_COMMIT=e34c502a3efe0e8b8166ea6148d55b73da5c8401


### PR DESCRIPTION
### What was the problem?
The 2.1.4 core docker image was crashing under Ubuntu systems
On Linux kernels with the membarrier syscall, this will happen because musl 1.1.22 and later use this and the default Docker seccomp profile does not whitelist that syscall (see related discussion in #204)
### How did I fix it?
Use node:10-alpine3.9 for base Docker image
### How to test it?
Run the container and see if it crashes or not
### Review checklist

* The PR resolves #202 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
