### PR TITLE
Add forger_backup.sh, forger_restore.sh

### DIFF
--- a/build/target/forger_backup.sh
+++ b/build/target/forger_backup.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+cd "$( cd -P -- "$( dirname -- "$0" )" && pwd -P )" || exit 2
+# shellcheck source=env.sh
+source "$( pwd )/env.sh"  # jq, node, pg_dump
+
+OUTPUT_DIRECTORY="${OUTPUT_DIRECTORY:-$PWD/backups}"
+SOURCE_DATABASE=$( node scripts/generate_config.js |jq --raw-output '.components.storage.database' )
+
+mkdir -p "$OUTPUT_DIRECTORY"
+
+function cleanup() {
+	rm -f "$TEMP_FILE"
+}
+
+TEMP_FILE=$( mktemp --tmpdir="$OUTPUT_DIRECTORY" )
+trap cleanup INT QUIT TERM EXIT
+
+OUTPUT_FILE="${OUTPUT_DIRECTORY}/forger_info-$( date +%s ).sql"
+
+pg_dump --no-owner --clean --table=forger_info --file="$TEMP_FILE" "$SOURCE_DATABASE"
+mv "$TEMP_FILE" "$OUTPUT_FILE"
+echo "Created $OUTPUT_FILE"

--- a/build/target/forger_restore.sh
+++ b/build/target/forger_restore.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+cd "$( cd -P -- "$( dirname -- "$0" )" && pwd -P )" || exit 2
+# shellcheck source=env.sh
+source "$( pwd )/env.sh"  # jq, node, psql
+
+function usage() {
+	echo "Usage: $0 <FILE>"
+	exit 1
+}
+
+BACKUP_FILE=${1:-}
+[ -f "$BACKUP_FILE" ] || usage
+
+TARGET_DATABASE=$( node scripts/generate_config.js |jq --raw-output '.components.storage.database' )
+
+psql --dbname="$TARGET_DATABASE" --file="$BACKUP_FILE" >/dev/null
+echo "Restored $BACKUP_FILE"


### PR DESCRIPTION
### What was the problem?
Scripts to backup and restore the `forger_info` table were requested in #208.

### How did I fix it?
Created `forger_backup.sh` and `forger_restore.sh` scripts.

### How to test it?

Backup:
```
~> ./forger_backup.sh
Created /home/lisk/lisk-test/backups/forger_info-1580226701.sql
```
(check output file)

Restore:
```
~> ./forger_restore.sh backups/forger_info-1580226224.sql
Restored backups/forger_info-1580226224.sql
```
(check `forger_info` table in database)

### Review checklist

* The PR resolves #208 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
