### PR TITLE
docker-compose command compatible with default Ubuntu 18.04 LTS repo

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -19,7 +19,7 @@ else
 endif
 
 up:
-	docker-compose up --detach
+	docker-compose up -d
 
 compose := docker-compose -f docker-compose.yml -f docker-compose.make.yml
 coldstart: $(lisk_net)_blockchain.db.gz up


### PR DESCRIPTION
As mentionned in LiskHQ/lisk-docs#441 the Makefile coldstart uses a docker-compose parameter available in since version 1.20.0. Unfortunately Ubuntu 18.04 LTS repo provides the 1.17.0 version. For the sake of convenience I propose to use the parameter available in older version.
The behaviour does not change.

Same as https://github.com/LiskHQ/lisk-core/pull/223 for 3.x branch