### PR TITLE
Delete tsconfig.tsbuildinfo on `npm run build` - Closes #225

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 		"lint": "tslint --format verbose --project .",
 		"lint:fix": "tslint --fix --project .",
 		"format": "prettier --write '**/*'",
-		"prebuild": "if test -d dist; then rm -r dist; fi",
+		"prebuild": "if test -d dist; then rm -r dist; fi; rm -f tsconfig.tsbuildinfo",
 		"build": "tsc",
 		"test": "mocha test"
 	},


### PR DESCRIPTION
Delete tsconfig.tsbuildinfo on `npm run build` to guarantee that tsc actually builds

### What was the problem?
This PR resolves #225 
### How was it solved?
<!--- Please describe your technical implementation -->
I added `rm -f tsconfig.tsbuildinfo` to "prebuild" in package.json
### How was it tested?
<!--- Please describe how you tested your changes -->
I followed the steps to reproduce described in #225 and made sure that I had the correct output