### PR TITLE
Add forger_*.sh scripts to builds

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -54,6 +54,8 @@ src/lisk-$(LISK_VERSION)-$(UNAME_S)-x86_64_image/finished: \
 		src/lisk-$(LISK_VERSION)-$(UNAME_S)-x86_64_image/REVISION \
 		src/lisk-$(LISK_VERSION)-$(UNAME_S)-x86_64_image/config.json \
 		src/lisk-$(LISK_VERSION)-$(UNAME_S)-x86_64_image/env.sh \
+		src/lisk-$(LISK_VERSION)-$(UNAME_S)-x86_64_image/forger_backup.sh \
+		src/lisk-$(LISK_VERSION)-$(UNAME_S)-x86_64_image/forger_restore.sh \
 		src/lisk-$(LISK_VERSION)-$(UNAME_S)-x86_64_image/lisk.sh \
 		src/lisk-$(LISK_VERSION)-$(UNAME_S)-x86_64_image/lisk_snapshot.sh \
 		src/lisk-$(LISK_VERSION)-$(UNAME_S)-x86_64_image/tune.sh \


### PR DESCRIPTION
### What was the problem?
This PR resolves #232

### How was it solved?
Include `forger_*.sh` scripts in builds.

### How was it tested?
Create build according to instructions in `build/README.md` and check the resulting tarball contains the aforementioned scripts.