### PR TITLE
Call 'lisk' instead of 'lisky'

### DIFF
--- a/build/target/lisk.sh
+++ b/build/target/lisk.sh
@@ -499,7 +499,7 @@ case $1 in
 "logs")
 	tail_logs
 	;;
-"lisky|lisk|commander")
+"lisky"|"lisk"|"commander")
 	lisk
 	;;
 "help")

--- a/build/target/lisk.sh
+++ b/build/target/lisk.sh
@@ -387,7 +387,7 @@ check_pid() {
 }
 
 lisk() {
-	node "$PWD/bin/lisk"
+	node "$PWD/bin/lisk" $@
 }
 
 tail_logs() {
@@ -500,7 +500,12 @@ case $1 in
 	tail_logs
 	;;
 "lisky"|"lisk"|"commander")
-	lisk
+	echo
+	echo "Note: invoking Lisk Commander from lisk.sh is deprecated and will be removed in a future version"
+	echo "      To run the included version of Lisk Commander directly, 'source env.sh' and then"
+	echo "      'bin/lisk'"
+	echo
+	lisk "${@:2}"
 	;;
 "help")
 	help


### PR DESCRIPTION
### What was the problem?
This PR resolves #136 
lisk.sh does not accept `lisky`, `lisk` or `commander` to call lisk-commander
### How was it solved?
<!--- Please describe your technical implementation -->
The intended `or` logic was inside of quotes and never got evaluated. This has been changed so that only lisky, lisk and commander are quoted separately
### How was it tested?
<!--- Please describe how you tested your changes -->
I ran './lisk.sh lisky', './lisk.sh lisk' and './lisk.sh commander' separately and verified that it worked.