### PR TITLE
Update env variables - Closes #287

### DIFF
--- a/docs/commands/start.md
+++ b/docs/commands/start.md
@@ -23,18 +23,28 @@ OPTIONS
   -l, --log=trace|debug|info|warn|error|fatal      File log level. Environment variable "LISK_FILE_LOG_LEVEL" can also
                                                    be used.
 
-  -n, --network=network                            Default network config to use. Environment variable "LISK_NETWORK"
-                                                   can also be used.
+  -n, --network=network                            [default: mainnet] Default network config to use. Environment
+                                                   variable "LISK_NETWORK" can also be used.
 
   -p, --port=port                                  Open port for the peer to peer incoming connections. Environment
                                                    variable "LISK_PORT" can also be used.
 
-  -x, --peer=peer                                  Seed peer to initially connect to in format of "ip:port".
-
   --console-log=trace|debug|info|warn|error|fatal  Console log level. Environment variable "LISK_CONSOLE_LOG_LEVEL" can
                                                    also be used.
 
+  --enable-http-api                                Enable HTTP API Plugin.
+
   --enable-ipc                                     Enable IPC communication.
+
+  --http-api-port=http-api-port                    Port to be used for HTTP API Plugin. Environment variable
+                                                   "LISK_HTTP_API_PORT" can also be used.
+
+  --http-api-whitelist=http-api-whitelist          List of IPs in comma separated value to allow the connection.
+                                                   Environment variable "LISK_HTTP_API_WHITELIST" can also be used.
+
+  --peers=peers                                    Seed peers to initially connect to in format of comma separated
+                                                   "ip:port". IP can be DNS name or IPV4 format. Environment variable
+                                                   "LISK_PEERS" can also be used.
 
 EXAMPLES
   start

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -16,7 +16,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { Command, flags as flagParser } from '@oclif/command';
 import * as fs from 'fs-extra';
-import { ApplicationConfig, utils, GenesisBlockJSON } from 'lisk-sdk';
+import { ApplicationConfig, utils, GenesisBlockJSON, HTTPAPIPlugin } from 'lisk-sdk';
 import {
 	getDefaultPath,
 	splitPath,
@@ -74,14 +74,21 @@ export default class StartCommand extends Command {
 			env: 'LISK_FILE_LOG_LEVEL',
 			options: LOG_OPTIONS,
 		}),
-		peer: flagParser.string({
-			char: 'x',
-			description: 'Seed peer to initially connect to in format of "ip:port".',
-			multiple: true,
+		peers: flagParser.string({
+			env: 'LISK_PEERS',
+			description: 'Seed peers to initially connect to in format of comma separated "ip:port". Environment variable "LISK_PEERS" can also be used.',
 		}),
 		'enable-http-api': flagParser.boolean({
 			description: 'Enable HTTP API Plugin.',
 			default: false,
+		}),
+		'http-api-port': flagParser.integer({
+			description: 'Port to be used for HTTP API Plugin. Environment variable "LISK_HTTP_API_PORT" can also be used.',
+			dependsOn: ['enable-http-api'],
+		}),
+		'http-api-whitelist': flagParser.string({
+			description: 'List of IPs in comma separated value to allow the connection. Environment variable "LISK_HTTP_API_WHITELIST" can also be used.',
+			dependsOn: ['enable-http-api'],
 		}),
 	};
 
@@ -130,11 +137,12 @@ export default class StartCommand extends Command {
 			config.network.port = flags.port;
 		}
 		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-		if (flags.peer) {
+		if (flags.peers) {
 			// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
 			config.network = config.network ?? {};
 			config.network.seedPeers = [];
-			for (const seed of flags.peer) {
+			const peers = flags.peers.split(',');
+			for (const seed of peers) {
 				const [ip, port] = seed.split(':');
 				if (!ip || !port || Number.isNaN(Number(port))) {
 					this.error('Invalid ip or port is specified.');
@@ -142,7 +150,17 @@ export default class StartCommand extends Command {
 				config.network.seedPeers.push({ ip, port: Number(port) });
 			}
 		}
-
+		// Plugin configs
+		if (flags['http-api-port'] !== undefined) {
+			// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+			config.plugins[HTTPAPIPlugin.alias] = config.plugins[HTTPAPIPlugin.alias] ?? {};
+			config.plugins[HTTPAPIPlugin.alias].port = flags['http-api-port'];
+		}
+		if (flags['http-api-whitelist'] !== undefined) {
+			// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+			config.plugins[HTTPAPIPlugin.alias] = config.plugins[HTTPAPIPlugin.alias] ?? {};
+			config.plugins[HTTPAPIPlugin.alias].whiteList = flags['http-api-whitelist'].split(',');
+		}
 		// Get application and start
 		try {
 			const app = getApplication(networkConfigs.genesisBlock, config, { enableHTTPAPI: flags['enable-http-api'] });

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -76,7 +76,7 @@ export default class StartCommand extends Command {
 		}),
 		peers: flagParser.string({
 			env: 'LISK_PEERS',
-			description: 'Seed peers to initially connect to in format of comma separated "ip:port". Environment variable "LISK_PEERS" can also be used.',
+			description: 'Seed peers to initially connect to in format of comma separated "ip:port". IP can be DNS name or IPV4 format. Environment variable "LISK_PEERS" can also be used.',
 		}),
 		'enable-http-api': flagParser.boolean({
 			description: 'Enable HTTP API Plugin.',

--- a/test/commands/start.spec.ts
+++ b/test/commands/start.spec.ts
@@ -159,7 +159,7 @@ describe('start', () => {
 
 	describe('when peer is specified', () => {
 		setupTest()
-			.command(['start', '--peer=localhost:12234'])
+			.command(['start', '--peers=localhost:12234'])
 			.it('should update the config value', () => {
 				const [,
 					usedConfig,
@@ -170,7 +170,7 @@ describe('start', () => {
 			});
 
 		setupTest()
-			.command(['start', '--peer=localhost:12234', '-x=74.49.3.35:2238'])
+			.command(['start', '--peers=localhost:12234,74.49.3.35:2238'])
 			.it('should update the config value', () => {
 				const [,
 					usedConfig,


### PR DESCRIPTION
### What was the problem?

This PR resolves #287 

### How was it solved?

Update peer flag to be `peers` and add `LISK_PEERS` corresponding to the flag.
Add http api plugin flag and environment variable for port and whitelist

### How was it tested?

```
./bin/run start -n devnet --enable-http-api --http-api-port 3333
```

and check if 3333 is open