### PR TITLE
Add Jenkins CI and nightly jobs

### DIFF
--- a/Jenkinsfile.ci
+++ b/Jenkinsfile.ci
@@ -1,0 +1,66 @@
+properties([
+	parameters([
+		string(name: 'COMMITISH_SDK', description: 'Commit-ish of LiskHQ/lisk-sdk to use', defaultValue: 'development' ),
+		string(name: 'COMMITISH_CORE', description: 'Commit-ish of LiskHQ/lisk-core to use', defaultValue: 'development' ),
+	])
+])
+
+pipeline {
+	agent { node { label 'lisk-core' } }
+	options { skipDefaultCheckout() }
+	stages {
+		stage('Checkout SCM') {
+			steps {
+				cleanWs()
+				dir('lisk-sdk') {
+					checkout([$class: 'GitSCM', branches: [[name: "${params.COMMITISH_SDK}" ]], userRemoteConfigs: [[url: 'https://github.com/LiskHQ/lisk-sdk']]])
+				}
+				dir('lisk-core') {
+					checkout([$class: 'GitSCM', branches: [[name: "${params.COMMITISH_CORE}" ]], userRemoteConfigs: [[url: 'https://github.com/LiskHQ/lisk-core']]])
+				}
+			}
+		}
+		stage('Build SDK') {
+			steps {
+				dir('lisk-sdk') {
+					nvm(readFile(".nvmrc").trim()) {
+						sh '''
+						npm install --global yarn
+						yarn
+						yarn build
+						'''
+						dir('sdk') {
+							sh '''
+							yarn link
+							'''
+						}
+					}
+				}
+			}
+		}
+		stage('Build Core') {
+			steps {
+				dir('lisk-core') {
+					nvm(readFile(".nvmrc").trim()) {
+						sh '''
+						npm install --registry https://npm.lisk.io/
+						npm install --global yarn
+						yarn link lisk-sdk
+						npm run build
+						'''
+					}
+				}
+			}
+		}
+		stage('Test Core') {
+			steps {
+				dir('lisk-core') {
+					nvm(readFile(".nvmrc").trim()) {
+						sh 'npm test'
+					}
+				}
+			}
+		}
+	}
+}
+// vim: filetype=groovy

--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -1,0 +1,99 @@
+pipeline {
+	agent { node { label 'lisk-core' } }
+	options { skipDefaultCheckout() }
+	stages {
+		stage('Checkout SCM') {
+			when { branch 'development' }
+			steps {
+				cleanWs()
+				dir('lisk-sdk') {
+					git branch: 'development', url: 'https://github.com/LiskHQ/lisk-sdk'
+				}
+				dir('lisk-core') {
+					git branch: 'development', url: 'https://github.com/LiskHQ/lisk-core'
+				}
+			}
+		}
+		stage('Build SDK') {
+			when { branch 'development' }
+			steps {
+				dir('lisk-sdk') {
+					nvm(readFile(".nvmrc").trim()) {
+						sh '''
+						npm install --global yarn
+						yarn
+						yarn build
+						'''
+					}
+				}
+			}
+		}
+		stage('Publish SDK') {
+			when { branch 'development' }
+			steps {
+				dir('lisk-sdk') {
+					nvm(readFile(".nvmrc").trim()) {
+						withCredentials([string(credentialsId: 'npm_lisk_io_registry_password', variable: 'PASS')]) {
+							sh '''#!/bin/bash -e
+							echo //npm.lisk.io/:_authToken=$( curl --silent https://npm.lisk.io/-/user/org.couchdb.user:jenkins/-rev/undefined -u jenkins:$PASS -X PUT \
+							  -d '{"_id":"org.couchdb.user:jenkins","name":"jenkins","password":"'$PASS'","type":"user","roles":[],"date":"2020-07-23T06:13:20.194Z","ok":"you are authenticated as 'undefined'"}' \
+							  -H content-type:application/json |jq --raw-output .token ) >~/.npmrc
+							'''
+						}
+						sh 'npx lerna publish --canary --preid nightly$BUILD_NUMBER --registry https://npm.lisk.io --ignore-scripts --yes |tee lerna_publish.log'
+					}
+				}
+			}
+			post {
+				always {
+				sh 'rm -f ~/.npmrc'
+				}
+			}
+		}
+		stage('Build Core') {
+			when { branch 'development' }
+			steps {
+				dir('lisk-core') {
+					nvm(readFile(".nvmrc").trim()) {
+						sh '''
+						package_version=$( jq --raw-output .version package.json )
+						jq '.version="'${package_version%%-*}-nightly$BUILD_NUMBER'"' package.json >package.json_; mv -f package.json_ package.json
+						# temporary workaround
+						jq '.private=false' package.json >package.json_; mv -f package.json_ package.json
+						# TODO: set SDK version
+						published_sdk_version=$( grep --after-context=100 '^Successfully published:' ../lisk-sdk/lerna_publish.log |grep '^ - lisk-sdk@' | cut -d @ -f 2 )
+						jq '.dependencies["lisk-sdk"]="'$published_sdk_version'"' package.json >package.json_; mv -f package.json_ package.json
+						npm install --registry https://npm.lisk.io/
+						npm install --global yarn
+						npm run build
+						npm test
+						'''
+					}
+				}
+			}
+		}
+		stage('Publish Core') {
+			when { branch 'development' }
+			steps {
+				dir('lisk-core') {
+					nvm(readFile(".nvmrc").trim()) {
+						withCredentials([string(credentialsId: 'npm_lisk_io_registry_password', variable: 'PASS')]) {
+							sh '''#!/bin/bash -e
+							echo //npm.lisk.io/:_authToken=$( curl --silent https://npm.lisk.io/-/user/org.couchdb.user:jenkins/-rev/undefined -u jenkins:$PASS -X PUT \
+							  -d '{"_id":"org.couchdb.user:jenkins","name":"jenkins","password":"'$PASS'","type":"user","roles":[],"date":"2020-07-23T06:13:20.194Z","ok":"you are authenticated as 'undefined'"}' \
+							  -H content-type:application/json |jq --raw-output .token ) >~/.npmrc
+							'''
+						}
+						sh 'npm publish --registry https://npm.lisk.io'
+					}
+				}
+			}
+			post {
+				always {
+				sh 'rm -f ~/.npmrc'
+				}
+			}
+		}
+	}
+}
+// vim: filetype=groovy


### PR DESCRIPTION
### What was the problem?

@shuse2 requested 2 jenkins jobs to run for every commit (CI) and once per day at night (nightly)

### How was it solved?

Add `Jenkinsfile.ci` and `Jenkinsfile.nightly`

### How was it tested?

- CI: https://jenkins.lisk.io/job/lisk-core/
- nightly: https://jenkins.lisk.io/job/nightly-builds/job/lisk-core-nightly/ (runs only on `development` branch)
  - replayed without that restriction for demonstration purposes: [jenkins-add-ci-and-nightly-jobs #7](https://jenkins.lisk.io/job/nightly-builds/job/lisk-core-nightly/job/jenkins-add-ci-and-nightly-jobs/7/)