### PR TITLE
Add core sdk:link command - Closes #259

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -29,3 +29,6 @@ dist/
 docker/.env*
 qa/
 bin
+
+*.pid
+*.gz

--- a/src/commands/sdk/link.ts
+++ b/src/commands/sdk/link.ts
@@ -40,6 +40,7 @@ export default class LinkCommand extends Command {
 		const sdkLocalPath = join(__dirname, '../../../', 'node_modules', 'lisk-sdk');
 
 		removeSync(sdkLocalPath);
-		symlinkSync(targetSDKFolder, sdkLocalPath);
+    symlinkSync(targetSDKFolder, sdkLocalPath);
+    this.log(`Linked '${targetSDKFolder as string}' to '${sdkLocalPath}'`);
 	}
 }

--- a/src/commands/sdk/link.ts
+++ b/src/commands/sdk/link.ts
@@ -19,25 +19,27 @@ import { symlinkSync, pathExistsSync, removeSync } from 'fs-extra';
 import { join } from 'path';
 
 export default class LinkCommand extends Command {
-  static description = 'Link an specific SDK folder given the parameter';
+	static description = 'Link an specific SDK folder given the parameter';
 
-  static examples = ['sdk:link /sdk/location/'];
+	static examples = ['sdk:link /sdk/location/'];
 
-  static args = [
-    { name: 'targetSDKFolder', required: true, description: 'The path to the lisk SDK folder' },
-  ]
+	static args = [
+		{ name: 'targetSDKFolder', required: true, description: 'The path to the lisk SDK folder' },
+	];
 
-  // eslint-disable-next-line class-methods-use-this, @typescript-eslint/require-await
-  async run(): Promise<void> {
-    const { args: { targetSDKFolder } } = this.parse(LinkCommand);
+	// eslint-disable-next-line class-methods-use-this, @typescript-eslint/require-await
+	async run(): Promise<void> {
+		const {
+			args: { targetSDKFolder },
+		} = this.parse(LinkCommand);
 
-    if (!pathExistsSync(targetSDKFolder)) {
-      throw new Error(`Path '${targetSDKFolder as string}' does not exist or no access allowed`);
-    }
+		if (!pathExistsSync(targetSDKFolder)) {
+			throw new Error(`Path '${targetSDKFolder as string}' does not exist or no access allowed`);
+		}
 
-    const sdkLocalPath = join(__dirname, '../../../', 'node_modules', 'lisk-sdk');
+		const sdkLocalPath = join(__dirname, '../../../', 'node_modules', 'lisk-sdk');
 
-    removeSync(sdkLocalPath);
-    symlinkSync(targetSDKFolder, sdkLocalPath);
-  }
+		removeSync(sdkLocalPath);
+		symlinkSync(targetSDKFolder, sdkLocalPath);
+	}
 }

--- a/src/commands/sdk/link.ts
+++ b/src/commands/sdk/link.ts
@@ -37,11 +37,7 @@ export default class LinkCommand extends Command {
 
     const sdkLocalPath = join(__dirname, '../../../', 'node_modules', 'lisk-sdk');
 
-    try {
-      removeSync(sdkLocalPath);
-      symlinkSync(targetSDKFolder, sdkLocalPath);
-    } catch (err) {
-      this.error(err);
-    }
+    removeSync(sdkLocalPath);
+    symlinkSync(targetSDKFolder, sdkLocalPath);
   }
 }

--- a/src/commands/sdk/link.ts
+++ b/src/commands/sdk/link.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import { Command } from '@oclif/command';
+import { symlinkSync, pathExistsSync, removeSync } from 'fs-extra';
+import { join } from 'path';
+
+export default class LinkCommand extends Command {
+  static description = 'Link an specific SDK folder given the parameter';
+
+  static examples = ['sdk:link', 'sdk:link /sdk/location/'];
+
+  static args = [
+    { name: 'targetSDKFolder' },
+  ]
+
+  // eslint-disable-next-line class-methods-use-this, @typescript-eslint/require-await
+  async run(): Promise<void> {
+    const { args: { targetSDKFolder } } = this.parse(LinkCommand);
+
+    if (targetSDKFolder === undefined) {
+      throw new Error('A path to the location of the SDK folder to be linked needs to be provided.');
+    }
+
+    if (!pathExistsSync(targetSDKFolder)) {
+      throw new Error(`Path '${targetSDKFolder as string}' does not exist or no access allowed`);
+    }
+
+    const sdkLocalPath = join(__dirname, '../../../', 'node_modules', 'lisk-sdk');
+
+    try {
+      removeSync(sdkLocalPath);
+      symlinkSync(targetSDKFolder, sdkLocalPath);
+    } catch (err) {
+      this.error(err);
+    }
+  }
+}

--- a/src/commands/sdk/link.ts
+++ b/src/commands/sdk/link.ts
@@ -40,7 +40,7 @@ export default class LinkCommand extends Command {
 		const sdkLocalPath = join(__dirname, '../../../', 'node_modules', 'lisk-sdk');
 
 		removeSync(sdkLocalPath);
-    symlinkSync(targetSDKFolder, sdkLocalPath);
-    this.log(`Linked '${targetSDKFolder as string}' to '${sdkLocalPath}'`);
+		symlinkSync(targetSDKFolder, sdkLocalPath);
+		this.log(`Linked '${targetSDKFolder as string}' to '${sdkLocalPath}'`);
 	}
 }

--- a/src/commands/sdk/link.ts
+++ b/src/commands/sdk/link.ts
@@ -21,19 +21,15 @@ import { join } from 'path';
 export default class LinkCommand extends Command {
   static description = 'Link an specific SDK folder given the parameter';
 
-  static examples = ['sdk:link', 'sdk:link /sdk/location/'];
+  static examples = ['sdk:link /sdk/location/'];
 
   static args = [
-    { name: 'targetSDKFolder' },
+    { name: 'targetSDKFolder', required: true, description: 'The path to the lisk SDK folder' },
   ]
 
   // eslint-disable-next-line class-methods-use-this, @typescript-eslint/require-await
   async run(): Promise<void> {
     const { args: { targetSDKFolder } } = this.parse(LinkCommand);
-
-    if (targetSDKFolder === undefined) {
-      throw new Error('A path to the location of the SDK folder to be linked needs to be provided.');
-    }
 
     if (!pathExistsSync(targetSDKFolder)) {
       throw new Error(`Path '${targetSDKFolder as string}' does not exist or no access allowed`);

--- a/test/commands/sdk/link.spec.ts
+++ b/test/commands/sdk/link.spec.ts
@@ -3,7 +3,7 @@ import * as sandbox from 'sinon';
 import * as fs from 'fs-extra';
 import { join } from 'path';
 
-describe('sdk:link command', () => {
+describe.only('sdk:link command', () => {
 	const setupTest = () =>
 		test
 			.stub(fs, 'removeSync', sandbox.stub().returns(null))

--- a/test/commands/sdk/link.spec.ts
+++ b/test/commands/sdk/link.spec.ts
@@ -45,9 +45,7 @@ describe('sdk:link command', () => {
 				expect(fs.pathExistsSync).to.be.calledWith(fakeSDKPath);
 				expect(fs.removeSync).calledWith(targetSDKPath);
 				expect(fs.symlinkSync).calledWith(fakeSDKPath, targetSDKPath);
-				expect(out.stdout).to.contain(
-					"Linked '/path/exists' to '/Users/pablo/Documents/LISK/Repos/lisk-core/node_modules/lisk-sdk'",
-				);
+				expect(out.stdout).to.contain(`Linked '/path/exists' to '${targetSDKPath}'`);
 			});
 	});
 });

--- a/test/commands/sdk/link.spec.ts
+++ b/test/commands/sdk/link.spec.ts
@@ -3,7 +3,7 @@ import * as sandbox from 'sinon';
 import * as fs from 'fs-extra';
 import { join } from 'path';
 
-describe.only('sdk:link command', () => {
+describe('sdk:link command', () => {
 	const setupTest = () =>
     test
       .stub(fs, 'removeSync', sandbox.stub().returns(null))

--- a/test/commands/sdk/link.spec.ts
+++ b/test/commands/sdk/link.spec.ts
@@ -5,45 +5,49 @@ import { join } from 'path';
 
 describe('sdk:link command', () => {
 	const setupTest = () =>
-    test
-      .stub(fs, 'removeSync', sandbox.stub().returns(null))
-      .stub(fs, 'symlinkSync', sandbox.stub().returns(null))
+		test
+			.stub(fs, 'removeSync', sandbox.stub().returns(null))
+			.stub(fs, 'symlinkSync', sandbox.stub().returns(null))
 			.stdout();
 
-  describe('sdk:link', () => {
-    test
-		.stdout()
-		.command(['sdk:link'])
-		.catch(error => {
-			return expect(error.message).to.contain(
-				'Missing 1 required arg:\ntargetSDKFolder  The path to the lisk SDK folder\nSee more help with --help',
-			);
-		})
-		.it('should throw an error when target folder is missing');
-  });
+	describe('sdk:link', () => {
+		test
+			.stdout()
+			.command(['sdk:link'])
+			.catch(error => {
+				return expect(error.message).to.contain(
+					'Missing 1 required arg:\ntargetSDKFolder  The path to the lisk SDK folder\nSee more help with --help',
+				);
+			})
+			.it('should throw an error when target folder is missing');
+	});
 
-  describe('sdk:link /path/does/not/exist', () => {
-    setupTest()
-    .stub(fs, 'pathExistsSync', sandbox.stub().withArgs('/path/does/not/exist').returns(false))
-    .command(['sdk:link', '/path/does/not/exist'])
-    .catch(error => {
-      return expect(error.message).to.contain('Path \'/path/does/not/exist\' does not exist or no access allowed');
-    })
-    .it('should throw an error when the target folder does not exist');
-  });
+	describe('sdk:link /path/does/not/exist', () => {
+		setupTest()
+			.stub(fs, 'pathExistsSync', sandbox.stub().withArgs('/path/does/not/exist').returns(false))
+			.command(['sdk:link', '/path/does/not/exist'])
+			.catch(error => {
+				return expect(error.message).to.contain(
+					"Path '/path/does/not/exist' does not exist or no access allowed",
+				);
+			})
+			.it('should throw an error when the target folder does not exist');
+	});
 
-  describe('sdk:link /path/exists', () => {
-    const fakeSDKPath = '/path/exists';
-    const targetSDKPath = join(__dirname, '../../../', 'node_modules', 'lisk-sdk');
+	describe('sdk:link /path/exists', () => {
+		const fakeSDKPath = '/path/exists';
+		const targetSDKPath = join(__dirname, '../../../', 'node_modules', 'lisk-sdk');
 
-    setupTest()
-    .stub(fs, 'pathExistsSync', sandbox.stub().withArgs('/path/exists').returns(true))
-    .command(['sdk:link', fakeSDKPath])
-    .it('should call file system functions with correct parameters', out => {
-      expect(fs.pathExistsSync).to.be.calledWith(fakeSDKPath);
-      expect(fs.removeSync).calledWith(targetSDKPath);
-      expect(fs.symlinkSync).calledWith(fakeSDKPath, targetSDKPath);
-      expect(out.stdout).to.contain("Linked '/path/exists' to '/Users/pablo/Documents/LISK/Repos/lisk-core/node_modules/lisk-sdk'");
-    });
-  });
+		setupTest()
+			.stub(fs, 'pathExistsSync', sandbox.stub().withArgs('/path/exists').returns(true))
+			.command(['sdk:link', fakeSDKPath])
+			.it('should call file system functions with correct parameters', out => {
+				expect(fs.pathExistsSync).to.be.calledWith(fakeSDKPath);
+				expect(fs.removeSync).calledWith(targetSDKPath);
+				expect(fs.symlinkSync).calledWith(fakeSDKPath, targetSDKPath);
+				expect(out.stdout).to.contain(
+					"Linked '/path/exists' to '/Users/pablo/Documents/LISK/Repos/lisk-core/node_modules/lisk-sdk'",
+				);
+			});
+	});
 });

--- a/test/commands/sdk/link.spec.ts
+++ b/test/commands/sdk/link.spec.ts
@@ -3,7 +3,7 @@ import * as sandbox from 'sinon';
 import * as fs from 'fs-extra';
 import { join } from 'path';
 
-describe.only('sdk:link command', () => {
+describe('sdk:link command', () => {
 	const setupTest = () =>
 		test
 			.stub(fs, 'removeSync', sandbox.stub().returns(null))

--- a/test/commands/sdk/link.spec.ts
+++ b/test/commands/sdk/link.spec.ts
@@ -39,10 +39,11 @@ describe.only('sdk:link command', () => {
     setupTest()
     .stub(fs, 'pathExistsSync', sandbox.stub().withArgs('/path/exists').returns(true))
     .command(['sdk:link', fakeSDKPath])
-    .it('should call file system functions with correct parameters', () => {
+    .it('should call file system functions with correct parameters', out => {
       expect(fs.pathExistsSync).to.be.calledWith(fakeSDKPath);
       expect(fs.removeSync).calledWith(targetSDKPath);
       expect(fs.symlinkSync).calledWith(fakeSDKPath, targetSDKPath);
+      expect(out.stdout).to.contain("Linked '/path/exists' to '/Users/pablo/Documents/LISK/Repos/lisk-core/node_modules/lisk-sdk'");
     });
   });
 });

--- a/test/commands/sdk/link.spec.ts
+++ b/test/commands/sdk/link.spec.ts
@@ -1,0 +1,48 @@
+import { expect, test } from '@oclif/test';
+import * as sandbox from 'sinon';
+import * as fs from 'fs-extra';
+import { join } from 'path';
+
+describe.only('sdk:link command', () => {
+	const setupTest = () =>
+    test
+      .stub(fs, 'removeSync', sandbox.stub().returns(null))
+      .stub(fs, 'symlinkSync', sandbox.stub().returns(null))
+			.stdout();
+
+  describe('sdk:link', () => {
+    test
+		.stdout()
+		.command(['sdk:link'])
+		.catch(error => {
+			return expect(error.message).to.contain(
+				'Missing 1 required arg:\ntargetSDKFolder  The path to the lisk SDK folder\nSee more help with --help',
+			);
+		})
+		.it('should throw an error when target folder is missing');
+  });
+
+  describe('sdk:link /path/does/not/exist', () => {
+    setupTest()
+    .stub(fs, 'pathExistsSync', sandbox.stub().withArgs('/path/does/not/exist').returns(false))
+    .command(['sdk:link', '/path/does/not/exist'])
+    .catch(error => {
+      return expect(error.message).to.contain('Path \'/path/does/not/exist\' does not exist or no access allowed');
+    })
+    .it('should throw an error when the target folder does not exist');
+  });
+
+  describe('sdk:link /path/exists', () => {
+    const fakeSDKPath = '/path/exists';
+    const targetSDKPath = join(__dirname, '../../../', 'node_modules', 'lisk-sdk');
+
+    setupTest()
+    .stub(fs, 'pathExistsSync', sandbox.stub().withArgs('/path/exists').returns(true))
+    .command(['sdk:link', fakeSDKPath])
+    .it('should call file system functions with correct parameters', () => {
+      expect(fs.pathExistsSync).to.be.calledWith(fakeSDKPath);
+      expect(fs.removeSync).calledWith(targetSDKPath);
+      expect(fs.symlinkSync).calledWith(fakeSDKPath, targetSDKPath);
+    });
+  });
+});


### PR DESCRIPTION
### What was the problem?

This PR resolves #259

### How was it solved?

- By adding sdk:link command

### How was it tested?

- unit test

- `npm i` on lisk-core
- run `ls node_modules/ |grep sdk` and you should see a directory 
- run `./bin/run sdk:link /path/to/lisk-sdk/sdk` 
- run `ls node_modules/ |grep sdk` and you should see a symlink
