### PR TITLE
Add core transaction:send command - Closes #272

### DIFF
--- a/src/commands/transaction/send.ts
+++ b/src/commands/transaction/send.ts
@@ -21,13 +21,13 @@ export default class SendCommand extends BaseIPCCommand {
 	};
 
 	static args = [
-		{ name: 'transaction', required: true, description: 'The transaction to be sent to the node' },
+		{ name: 'transaction', required: true, description: 'The transaction to be sent to the node in base64 string' },
 	];
 
 	async run(): Promise<void> {
 		const {
 			args: { transaction },
-		} = this.parse(this.constructor as typeof SendCommand);
+		} = this.parse(SendCommand);
 		if (!validator.isBase64String(transaction)) {
 			throw new Error('The transaction must be provided as a base64 encoded string');
 		}

--- a/src/commands/transaction/send.ts
+++ b/src/commands/transaction/send.ts
@@ -21,7 +21,11 @@ export default class SendCommand extends BaseIPCCommand {
 	};
 
 	static args = [
-		{ name: 'transaction', required: true, description: 'The transaction to be sent to the node in base64 string' },
+		{
+			name: 'transaction',
+			required: true,
+			description: 'The transaction to be sent to the node encoded as base64 string',
+		},
 	];
 
 	async run(): Promise<void> {

--- a/src/commands/transaction/send.ts
+++ b/src/commands/transaction/send.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import { validator } from 'lisk-sdk';
+import BaseIPCCommand from '../../base_ipc';
+
+export default class SendCommand extends BaseIPCCommand {
+	static flags = {
+		...BaseIPCCommand.flags,
+	};
+
+	static args = [
+		{ name: 'transaction', required: true, description: 'The transaction to be sent to the node' },
+	];
+
+	async run(): Promise<void> {
+		const {
+			args: { transaction },
+		} = this.parse(this.constructor as typeof SendCommand);
+		if (!validator.isBase64String(transaction)) {
+			throw new Error('The transaction must be provided as a base64 encoded string');
+		}
+
+		const { transactionId } = await this._channel.invoke('app:postTransaction', { transaction });
+		this.log(`Transaction with id: '${transactionId as string}' received by node`);
+	}
+}

--- a/test/commands/transaction/send.spec.ts
+++ b/test/commands/transaction/send.spec.ts
@@ -22,7 +22,7 @@ import { IPCChannel } from 'lisk-sdk';
 import * as appUtils from '../../../src/utils/application';
 import { createTransferTransaction, encodeTransactionFromJSON } from '../../utils/transactions';
 
-export const baseTransactionSchema = {
+const baseTransactionSchema = {
 	$id: 'lisk/base-transaction',
 	type: 'object',
 	required: ['type', 'nonce', 'fee', 'senderPublicKey', 'asset'],

--- a/test/commands/transaction/send.spec.ts
+++ b/test/commands/transaction/send.spec.ts
@@ -86,7 +86,7 @@ const transactionsAssets = {
 	8: transferAssetSchema,
 };
 
-describe.only('transaction:send command', () => {
+describe('transaction:send command', () => {
 	const { id: transactionId, ...transferTransaction } = createTransferTransaction({
 		amount: '1',
 		fee: '0.2',

--- a/test/commands/transaction/send.spec.ts
+++ b/test/commands/transaction/send.spec.ts
@@ -86,7 +86,7 @@ const transactionsAssets = {
 	8: transferAssetSchema,
 };
 
-describe('transaction:send command', () => {
+describe.only('transaction:send command', () => {
 	const { id: transactionId, ...transferTransaction } = createTransferTransaction({
 		amount: '1',
 		fee: '0.2',
@@ -126,7 +126,7 @@ describe('transaction:send command', () => {
 			.command(['transaction:send'])
 			.catch((error: Error) =>
 				expect(error.message).to.contain(
-					'Missing 1 required arg:\ntransaction  The transaction to be sent to the node\nSee more help with --help',
+					'Missing 1 required arg:\ntransaction  The transaction to be sent to the node encoded as base64 string\nSee more help with --help',
 				),
 			)
 			.it('should throw an error when transaction argument is not provided.');

--- a/test/commands/transaction/send.spec.ts
+++ b/test/commands/transaction/send.spec.ts
@@ -1,0 +1,191 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+
+import { expect, test } from '@oclif/test';
+import * as sandbox from 'sinon';
+import * as fs from 'fs-extra';
+import { join } from 'path';
+import { IPCChannel } from 'lisk-sdk';
+
+import * as appUtils from '../../../src/utils/application';
+import { createTransferTransaction, encodeTransactionFromJSON } from '../../utils/transactions';
+
+export const baseTransactionSchema = {
+	$id: 'lisk/base-transaction',
+	type: 'object',
+	required: ['type', 'nonce', 'fee', 'senderPublicKey', 'asset'],
+	properties: {
+		type: {
+			dataType: 'uint32',
+			fieldNumber: 1,
+		},
+		nonce: {
+			dataType: 'uint64',
+			fieldNumber: 2,
+		},
+		fee: {
+			dataType: 'uint64',
+			fieldNumber: 3,
+		},
+		senderPublicKey: {
+			dataType: 'bytes',
+			fieldNumber: 4,
+		},
+		asset: {
+			dataType: 'bytes',
+			fieldNumber: 5,
+		},
+		signatures: {
+			type: 'array',
+			items: {
+				dataType: 'bytes',
+			},
+			fieldNumber: 6,
+		},
+	},
+};
+
+const transferAssetSchema = {
+	$id: 'lisk/transfer-transaction',
+	title: 'Transfer transaction asset',
+	type: 'object',
+	required: ['amount', 'recipientAddress', 'data'],
+	properties: {
+		amount: {
+			dataType: 'uint64',
+			fieldNumber: 1,
+		},
+		recipientAddress: {
+			dataType: 'bytes',
+			fieldNumber: 2,
+			minLength: 20,
+			maxLength: 20,
+		},
+		data: {
+			dataType: 'string',
+			fieldNumber: 3,
+			minLength: 0,
+			maxLength: 64,
+		},
+	},
+};
+
+const transactionsAssets = {
+	8: transferAssetSchema,
+};
+
+describe.only('transaction:send command', () => {
+	const { id: transactionId, ...transferTransaction } = createTransferTransaction({
+		amount: '1',
+		fee: '0.2',
+		nonce: 1,
+		recipientAddress: 'CQP0xctZmnkorvJ+MU6YKR0eOIg=',
+	});
+	const encodedTransaction = encodeTransactionFromJSON(
+		transferTransaction as any,
+		baseTransactionSchema,
+		transactionsAssets,
+	);
+	const fsStub = sandbox.stub().returns(true);
+	const printJSONStub = sandbox.stub();
+	const ipcInvokeStub = sandbox.stub();
+	const pathToAppPIDFiles = join(__dirname, 'fake_test_app');
+	const ipcStartAndListenStub = sandbox.stub();
+	ipcInvokeStub.withArgs('app:getSchema').resolves({
+		baseTransaction: baseTransactionSchema,
+		transactionsAssets,
+	});
+
+	afterEach(() => {
+		ipcInvokeStub.resetHistory();
+		printJSONStub.resetHistory();
+	});
+
+	const setupTest = () =>
+		test
+			.stub(appUtils, 'isApplicationRunning', sandbox.stub().returns(true))
+			.stub(fs, 'existsSync', fsStub)
+			.stub(IPCChannel.prototype, 'startAndListen', ipcStartAndListenStub)
+			.stub(IPCChannel.prototype, 'invoke', ipcInvokeStub)
+			.stdout();
+
+	describe('transaction:send', () => {
+		setupTest()
+			.command(['transaction:send'])
+			.catch((error: Error) =>
+				expect(error.message).to.contain(
+					'Missing 1 required arg:\ntransaction  The transaction to be sent to the node\nSee more help with --help',
+				),
+			)
+			.it('should throw an error when transaction argument is not provided.');
+	});
+
+	describe('transaction:send <base64 encoded transaction> --data-path=<path to a not running app>', () => {
+		setupTest()
+			.stub(appUtils, 'isApplicationRunning', sandbox.stub().returns(false))
+			.command(['transaction:send', encodedTransaction, `--data-path=${pathToAppPIDFiles}`])
+			.catch((error: Error) =>
+				expect(error.message).to.contain(
+					`Application at data path ${pathToAppPIDFiles} is not running.`,
+				),
+			)
+			.it('should throw an error when the application for the provided path is not running.');
+	});
+
+	describe('transaction:send <invalid base64 string> --data-path=<path to a not running app>', () => {
+		setupTest()
+			.command(['transaction:send', '%%%%%%', `--data-path=${pathToAppPIDFiles}`])
+			.catch((error: Error) => {
+				expect(error.message).to.contain(
+					'The transaction must be provided as a base64 encoded string',
+				);
+			})
+			.it('should throw error.');
+	});
+
+	describe('transaction:send <base64 encoded transaction> --data-path=<path to a running app>', () => {
+		ipcInvokeStub
+			.withArgs('app:postTransaction', { transaction: encodedTransaction })
+			.resolves({ transactionId });
+
+		setupTest()
+			.command(['transaction:send', encodedTransaction, `--data-path=${pathToAppPIDFiles}`])
+			.it('should return the id of the sent transaction', out => {
+				expect(ipcInvokeStub).to.have.been.calledWithExactly('app:postTransaction', {
+					transaction: encodedTransaction,
+				});
+				expect(out.stdout).to.contain(`Transaction with id: '${transactionId}' received by node`);
+			});
+	});
+
+	describe('transaction:send <base64 encoded invalid transaction> --data-path=<path to a not running app>', () => {
+		ipcInvokeStub
+			.withArgs('app:postTransaction', { transaction: 'invalidAccountNonceTrs' })
+			.rejects(
+				new Error(
+					'Error: Lisk validator found 1 error[s]:\nIncompatible transaction nonce for account: 0EaZ5XxKOEbJiPPBUwZ5b46uXBw=, Tx Nonce: 0, Account Nonce: 1',
+				),
+			);
+
+		setupTest()
+			.command(['transaction:send', 'invalidAccountNonceTrs', `--data-path=${pathToAppPIDFiles}`])
+			.catch((error: Error) => {
+				expect(error.message).to.contain(
+					'Error: Lisk validator found 1 error[s]:\nIncompatible transaction nonce for account: 0EaZ5XxKOEbJiPPBUwZ5b46uXBw=, Tx Nonce: 0, Account Nonce: 1',
+				);
+			})
+			.it('should throw error.');
+	});
+});


### PR DESCRIPTION
### What was the problem?

This PR resolves #272

### How was it solved?

By adding the command to send a transaction to the node by IPC

### How was it tested?

- Unit tests
- Create a transaction and get the encoded base64 representation then run the command. Example: 
```
./bin/run transaction:send CAgQABiAreIEIiAP6aPxohtVMPJ/h6QUtUnnmpQL8k/fKy8F5/Iq7uzIaioeCIDIr6AlEhTKU+nitO+qcqESWBGjhj99dxWx/hoAMkBI5kK8+Hn3/XeFXavYARJWL0SI4Pc0Pky5CJrX8rKy6FgLzwQoG1dyDrw7DszWhG+vpF6LZ/XOC/H772gDKJ0G --data-path=/Users/pablo/.lisk/devnet/
```

you should get a message `Transaction with id: 'cpKrfcuFVfkjw2QK3hLmanu4v73flpI58Doa0WxK3us=' received by node`

This PR depends on https://github.com/LiskHQ/lisk-sdk/pull/5597 so switch and build its branch or wait for it to be merged before testing.