### PR TITLE
Add forger-info:export command - Closes #268

### DIFF
--- a/src/commands/forger-info/export.ts
+++ b/src/commands/forger-info/export.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+
+import * as tar from 'tar';
+import { join } from 'path';
+import { Command, flags as flagParser } from '@oclif/command';
+import { getDefaultPath, getFullPath, getForgerDBPath } from '../../utils/path';
+
+export default class ExportCommand extends Command {
+	static description = 'Export forger data to a given data path';
+
+	static examples = [
+		'forger-info:export',
+		'forger-info:export --data-path ./data --output ./my/path/',
+	];
+
+	static flags = {
+		'data-path': flagParser.string({
+			char: 'd',
+			description:
+				'Directory path to specify where node data is stored. Environment variable "LISK_DATA_PATH" can also be used.',
+			env: 'LISK_DATA_PATH',
+		}),
+		output: flagParser.string({
+			char: 'o',
+			description: 'The output directory. Default will set to current working directory.',
+		}),
+	};
+
+	async run(): Promise<void> {
+		const { flags } = this.parse(ExportCommand);
+		const dataPath = flags['data-path'] ? flags['data-path'] : getDefaultPath();
+		const forgerDataPath = getForgerDBPath(dataPath);
+		const exportPath = flags.output ? flags.output : process.cwd();
+
+		this.log('Exporting ForgerInfo:');
+		this.log(`   ${getFullPath(forgerDataPath)}`);
+		await tar.create(
+			{
+				gzip: true,
+				file: join(exportPath, 'forger.db.gz'),
+				cwd: join(dataPath, 'data'),
+			},
+			['forger.db'],
+		);
+
+		this.log('Export completed:');
+		this.log(`   ${getFullPath(exportPath)}`);
+	}
+}

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -54,6 +54,9 @@ export const getConfigFilePath = (dataPath: string, network: string): string =>
 export const getBlockchainDBPath = (dataPath: string): string =>
 	path.join(dataPath, 'data', 'blockchain.db');
 
+export const getForgerDBPath = (dataPath: string): string =>
+	path.join(dataPath, 'data', 'forger.db');
+
 export const getPidPath = (dataPath: string): string =>
 	path.join(dataPath, 'tmp', 'pids', 'controller.pid');
 

--- a/test/commands/forger-info/export.spec.ts
+++ b/test/commands/forger-info/export.spec.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+
+import * as tar from 'tar';
+import { expect, test } from '@oclif/test';
+import * as sandbox from 'sinon';
+import { homedir } from 'os';
+import { join } from 'path';
+
+const defaultDataPath = join(homedir(), '.lisk', 'default');
+
+describe('forger-info:export', () => {
+	const tarCreateStub = sandbox.stub().resolves(true);
+
+	const setupTest = () => test.stub(tar, 'create', tarCreateStub).stdout();
+
+	afterEach(() => {
+		tarCreateStub.reset();
+	});
+
+	describe('when starting without flag', () => {
+		setupTest()
+			.command(['forger-info:export'])
+			.it('should compress "forger.db" for default data path', () => {
+				expect(tarCreateStub).to.have.been.calledOnce;
+				expect(tarCreateStub).to.have.been.calledWithExactly(
+					{
+						cwd: join(defaultDataPath, 'data'),
+						file: join(process.cwd(), 'forger.db.gz'),
+						gzip: true,
+					},
+					['forger.db'],
+				);
+			});
+	});
+
+	describe('when starting with particular data-path', () => {
+		setupTest()
+			.command(['forger-info:export', '--data-path=/my/app/'])
+			.it('should compress "forger.db" for given data path', () => {
+				expect(tarCreateStub).to.have.been.calledOnce;
+				expect(tarCreateStub).to.have.been.calledWithExactly(
+					{
+						cwd: join('/my/app/', 'data'),
+						file: join(process.cwd(), 'forger.db.gz'),
+						gzip: true,
+					},
+					['forger.db'],
+				);
+			});
+	});
+
+	describe('when starting with particular export path', () => {
+		setupTest()
+			.command(['forger-info:export', '--output=/my/dir/'])
+			.it('should compress "forger.db" for given data path', () => {
+				expect(tarCreateStub).to.have.been.calledOnce;
+				expect(tarCreateStub).to.have.been.calledWithExactly(
+					{
+						cwd: join(defaultDataPath, 'data'),
+						file: join('/my/dir/', 'forger.db.gz'),
+						gzip: true,
+					},
+					['forger.db'],
+				);
+			});
+	});
+});


### PR DESCRIPTION
### What was the problem?

This PR resolves #268 

### How was it solved?

- Add command `forger-info:export` by creating `forger-info/export.ts`, handling data-path and output flags for source and destination
- Add unit tests

### How was it tested?

- `npm t`
- `./bin/run forger-info:export --data-path={source_path} --output={destination_path}`
