### PR TITLE
Add forger-info:import command - Closes #269

### DIFF
--- a/src/commands/forger-info/import.ts
+++ b/src/commands/forger-info/import.ts
@@ -45,7 +45,10 @@ export default class ImportCommand extends Command {
 				'Directory path to specify where node data is stored. Environment variable "LISK_DATA_PATH" can also be used.',
 			env: 'LISK_DATA_PATH',
 		}),
-		force: flagParser.boolean({ char: 'f' }),
+		force: flagParser.boolean({
+			char: 'f',
+			description: 'To overwrite the existing data if present.',
+		}),
 	};
 
 	async run(): Promise<void> {
@@ -55,11 +58,11 @@ export default class ImportCommand extends Command {
 		const forgerDBPath = getForgerDBPath(dataPath);
 
 		if (path.extname(sourcePath) !== '.gz') {
-			throw new Error('Forger data should be provided in gzip format.');
+			this.error('Forger data should be provided in gzip format.');
 		}
 
 		if (!flags.force && fs.existsSync(forgerDBPath)) {
-			throw new Error(`Forger data already exists at ${dataPath}. Use --force flag to overwrite`);
+			this.error(`Forger data already exists at ${dataPath}. Use --force flag to overwrite`);
 		}
 
 		fs.ensureDirSync(forgerDBPath);

--- a/src/utils/download.ts
+++ b/src/utils/download.ts
@@ -16,6 +16,7 @@
 import * as crypto from 'crypto';
 import * as axios from 'axios';
 import * as fs from 'fs-extra';
+import * as tar from 'tar';
 
 export interface FileInfo {
 	readonly fileName: string;
@@ -97,3 +98,10 @@ export const downloadAndValidate = async (url: string, dir: string): Promise<voi
 
 	await verifyChecksum(filePath, checksum);
 };
+
+export const extract = async (filePath: string, fileName: string, outDir: string): Promise<void> =>
+	tar.x({
+		file: `${filePath}/${fileName}`,
+		cwd: outDir,
+		strip: 1,
+	});

--- a/test/commands/forger-info/import.spec.ts
+++ b/test/commands/forger-info/import.spec.ts
@@ -1,0 +1,123 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+
+import { expect, test } from '@oclif/test';
+import * as sandbox from 'sinon';
+import * as fs from 'fs-extra';
+import { homedir } from 'os';
+import * as path from 'path';
+import { getForgerDBPath } from '../../../src/utils/path';
+import * as downloadUtils from '../../../src/utils/download';
+
+const defaultDataPath = path.join(homedir(), '.lisk', 'default');
+const defaultForgerDBPath = getForgerDBPath(defaultDataPath);
+const pathToForgerGzip = '/path/to/forger.db.gz';
+
+describe('forger-info:import', () => {
+	const fsExistsSyncStub = sandbox.stub().returns(false);
+	const pathExtnameStub = sandbox.stub().returns('.gz');
+	const fsEnsureDirSyncStub = sandbox.stub();
+	const extractStub = sandbox.stub();
+
+	const setupTest = () =>
+		test
+			.stub(fs, 'existsSync', fsExistsSyncStub)
+			.stub(path, 'extname', pathExtnameStub)
+			.stub(fs, 'ensureDirSync', fsEnsureDirSyncStub)
+			.stub(downloadUtils, 'extract', extractStub)
+			.stdout()
+			.stderr();
+
+	afterEach(() => {
+		fsExistsSyncStub.resetHistory();
+		pathExtnameStub.resetHistory();
+		fsEnsureDirSyncStub.resetHistory();
+		extractStub.resetHistory();
+	});
+
+	describe('when importing with no path argument', () => {
+		setupTest()
+			.command(['forger-info:import'])
+			.catch((error: Error) => expect(error.message).to.contain('Missing 1 required arg:'))
+			.it('should throw an error when no arguments are provided.');
+	});
+
+	describe('when importing with no existing forger data', () => {
+		setupTest()
+			.command(['forger-info:import', pathToForgerGzip])
+			.it('should import "forger.db" from given path', () => {
+				expect(fsExistsSyncStub).to.have.been.calledOnce;
+				expect(fsExistsSyncStub).to.have.been.calledWithExactly(defaultForgerDBPath);
+				expect(fsEnsureDirSyncStub).to.have.been.calledOnce;
+				expect(fsEnsureDirSyncStub).to.have.been.calledWithExactly(defaultForgerDBPath);
+				expect(extractStub).to.have.been.calledOnce;
+				expect(extractStub).to.have.been.calledWithExactly(
+					path.dirname(pathToForgerGzip),
+					'forger.db.gz',
+					defaultForgerDBPath,
+				);
+			});
+	});
+
+	describe('when importing with --data-path flag', () => {
+		const dataPath = getForgerDBPath('/my/app/');
+		setupTest()
+			.command(['forger-info:import', pathToForgerGzip, '--data-path=/my/app/'])
+			.it('should import "forger.db" to given data-path', () => {
+				expect(fsExistsSyncStub).to.have.been.calledOnce;
+				expect(fsExistsSyncStub).to.have.been.calledWithExactly(dataPath);
+				expect(fsEnsureDirSyncStub).to.have.been.calledOnce;
+				expect(fsEnsureDirSyncStub).to.have.been.calledWithExactly(dataPath);
+				expect(extractStub).to.have.been.calledOnce;
+				expect(extractStub).to.have.been.calledWithExactly(
+					path.dirname(pathToForgerGzip),
+					'forger.db.gz',
+					dataPath,
+				);
+			});
+	});
+
+	describe('when importing with existing forger data', () => {
+		beforeEach(() => {
+			fsExistsSyncStub.returns(true);
+		});
+
+		describe('when importing without --force flag', () => {
+			setupTest()
+				.command(['forger-info:import', pathToForgerGzip])
+				.catch((error: Error) =>
+					expect(error.message).to.contain(
+						`Forger data already exists at ${defaultDataPath}. Use --force flag to overwrite`,
+					),
+				)
+				.it('should log error and return');
+		});
+
+		describe('when importing with --force flag', () => {
+			setupTest()
+				.command(['forger-info:import', pathToForgerGzip, '--force'])
+				.it('should import "forger.db" to given data-path', () => {
+					expect(fsEnsureDirSyncStub).to.have.been.calledOnce;
+					expect(fsEnsureDirSyncStub).to.have.been.calledWithExactly(defaultForgerDBPath);
+					expect(extractStub).to.have.been.calledOnce;
+					expect(extractStub).to.have.been.calledWithExactly(
+						path.dirname(pathToForgerGzip),
+						'forger.db.gz',
+						defaultForgerDBPath,
+					);
+				});
+		});
+	});
+});


### PR DESCRIPTION
### What was the problem?

This PR resolves #269 

### How was it solved?

- Add `forger-info:import` command
- Add related unit tests

### How was it tested?

`npm run test`
`./run forger-info:import`
`./run forger-info:import {path_source_gzip} --force`
`./run forger-info:import {path_source_gzip} --data-path {custom_data_path}`

