### PR TITLE
Add core transaction:create command - Closes #271

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,6 +5,8 @@ Dockerfile
 LICENSE
 .DS_Store
 data/
+.idea
+logs/
 
 .gitkeep
 mocha.opts

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,6 +39,7 @@ pipeline {
 						npm install --global yarn
 						yarn
 						yarn build
+						npx lerna exec yarn unlink
 						npx lerna exec yarn link
 						npx lerna --loglevel error list >../packages
 						'''

--- a/Jenkinsfile.ci
+++ b/Jenkinsfile.ci
@@ -1,7 +1,6 @@
 properties([
 	parameters([
 		string(name: 'COMMITISH_SDK', description: 'Commit-ish of LiskHQ/lisk-sdk to use', defaultValue: 'development' ),
-		string(name: 'COMMITISH_CORE', description: 'Commit-ish of LiskHQ/lisk-core to use', defaultValue: 'development' ),
 	])
 ])
 
@@ -28,6 +27,7 @@ pipeline {
 						npm install --global yarn
 						yarn
 						yarn build
+						npx lerna exec yarn unlink
 						npx lerna exec yarn link
 						npx lerna --loglevel error list >../packages
 						'''

--- a/src/base_forging.ts
+++ b/src/base_forging.ts
@@ -15,6 +15,8 @@
 
 import * as inquirer from 'inquirer';
 import { flags as flagParser } from '@oclif/command';
+
+import { flags as commonFlags } from './utils/flags';
 import BaseIPCCommand from './base_ipc';
 
 interface Args {
@@ -32,10 +34,7 @@ export class BaseForgingCommand extends BaseIPCCommand {
 
 	static flags = {
 		...BaseIPCCommand.flags,
-		password: flagParser.string({
-			char: 'p',
-			description: 'Password to decrypt the encrypted passphrase.',
-		}),
+		password: flagParser.string(commonFlags.password),
 	};
 
 	protected forging!: boolean;

--- a/src/base_ipc.ts
+++ b/src/base_ipc.ts
@@ -56,7 +56,6 @@ export interface Codec {
 		assetSchema: Schema,
 		transactionObject: Record<string, unknown>,
 	) => Record<string, unknown>;
-
 }
 
 const prettyDescription = 'Prints JSON in pretty format rather than condensed.';
@@ -212,10 +211,7 @@ export default abstract class BaseIPCCommand extends Command {
 				assetSchema: Schema,
 				transactionObject: Record<string, unknown>,
 			): Record<string, unknown> => {
-				const assetJSON = codec.toJSON(
-					assetSchema,
-					transactionObject.asset as object,
-				);
+				const assetJSON = codec.toJSON(assetSchema, transactionObject.asset as object);
 
 				const transactionJSON = codec.toJSON(this._schema.baseTransaction, {
 					...transactionObject,
@@ -225,13 +221,13 @@ export default abstract class BaseIPCCommand extends Command {
 				return {
 					...transactionJSON,
 					asset: assetJSON,
-				}
+				};
 			},
-			encodeTransaction: (assetSchema: Schema, transactionObject: Record<string, unknown>): string => {
-				const assetBuffer = codec.encode(
-					assetSchema,
-					transactionObject.asset as object,
-				);
+			encodeTransaction: (
+				assetSchema: Schema,
+				transactionObject: Record<string, unknown>,
+			): string => {
+				const assetBuffer = codec.encode(assetSchema, transactionObject.asset as object);
 
 				const transactionBuffer = codec.encode(this._schema.baseTransaction, {
 					...transactionObject,

--- a/src/base_ipc.ts
+++ b/src/base_ipc.ts
@@ -204,10 +204,7 @@ export default abstract class BaseIPCCommand extends Command {
 				});
 			},
 			encodeTransaction: (transactionObject: Record<string, unknown>): Buffer => {
-				const transactionBuffer = codec.encode(
-					this._schema.baseTransaction,
-					transactionObject,
-				);
+				const transactionBuffer = codec.encode(this._schema.baseTransaction, transactionObject);
 
 				return transactionBuffer;
 			},

--- a/src/base_ipc.ts
+++ b/src/base_ipc.ts
@@ -48,7 +48,7 @@ export interface Codec {
 	decodeBlock: (data: Buffer | string) => Record<string, unknown>;
 	decodeTransaction: (data: Buffer | string) => Record<string, unknown>;
 	encodeTransaction: (transactionObject: Record<string, unknown>, assetSchema: Schema) => Buffer;
-	transactionObject: (
+	transactionToJSON: (
 		transactionObject: Record<string, unknown>,
 		assetSchema: Schema,
 	) => Record<string, unknown>;
@@ -189,7 +189,7 @@ export default abstract class BaseIPCCommand extends Command {
 					asset: transactionAsset,
 				};
 			},
-			transactionObject: (
+			transactionToJSON: (
 				transactionObject: Record<string, unknown>,
 				assetSchema: Schema,
 			): Record<string, unknown> => {

--- a/src/base_ipc.ts
+++ b/src/base_ipc.ts
@@ -14,7 +14,7 @@
  */
 
 import { Command, flags as flagParser } from '@oclif/command';
-import { codec, cryptography, IPCChannel, transactions } from 'lisk-sdk';
+import { codec, cryptography, IPCChannel } from 'lisk-sdk';
 import { getDefaultPath, getSocketsPath, splitPath } from './utils/path';
 import { flags as commonFlags } from './utils/flags';
 import { isApplicationRunning } from './utils/application';
@@ -47,7 +47,7 @@ export interface Codec {
 	decodeAccount: (data: Buffer | string) => Record<string, unknown>;
 	decodeBlock: (data: Buffer | string) => Record<string, unknown>;
 	decodeTransaction: (data: Buffer | string) => Record<string, unknown>;
-	encodeTransaction: (transactionObject: Record<string, unknown>, assetSchema: Schema) => string;
+	encodeTransaction: (transactionObject: Record<string, unknown>, assetSchema: Schema) => Buffer;
 	transactionObject: (
 		transactionObject: Record<string, unknown>,
 		assetSchema: Schema,
@@ -203,15 +203,13 @@ export default abstract class BaseIPCCommand extends Command {
 					asset: assetBuffer,
 				});
 			},
-			encodeTransaction: (transactionObject: Record<string, unknown>): string => {
+			encodeTransaction: (transactionObject: Record<string, unknown>): Buffer => {
 				const transactionBuffer = codec.encode(
 					this._schema.baseTransaction,
-					codec.fromJSON(this._schema.baseTransaction, {
-						...transactionObject,
-					}),
+					transactionObject,
 				);
 
-				return transactionBuffer.toString('base64');
+				return transactionBuffer;
 			},
 		};
 	}

--- a/src/commands/passphrase/decrypt.ts
+++ b/src/commands/passphrase/decrypt.ts
@@ -22,7 +22,7 @@ interface Args {
 	readonly encryptedPassphrase?: string;
 }
 
-const processInputs = (password: string, encryptedPassphrase: string) => {
+const processInputs = (password: string, encryptedPassphrase: string): Record<string, string> => {
 	const encryptedPassphraseObject = cryptography.parseEncryptedPassphrase(encryptedPassphrase);
 	const passphrase = cryptography.decryptPassphraseWithPassword(
 		encryptedPassphraseObject,

--- a/src/commands/transaction/create.ts
+++ b/src/commands/transaction/create.ts
@@ -1,0 +1,174 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import { flags as flagParser } from '@oclif/command';
+import { codec, cryptography, transactions, validator } from 'lisk-sdk';
+import BaseIPCCommand from '../../base_ipc';
+import { flags as commonFlags } from '../../utils/flags';
+import { getAssetFromPrompt, getPassphraseFromPrompt } from '../../utils/reader';
+import { LiskValidationError } from '../../../../lisk-sdk/node_modules/@liskhq/lisk-validator/dist-node';
+
+interface Args {
+	readonly nonce: string;
+	readonly fee: string;
+	readonly type: number;
+	readonly networkIdentifier: string;
+}
+
+interface MultiSignatureKeys {
+	readonly mandatoryKeys: Array<Buffer>;
+	readonly optionalKeys: Array<Buffer>;
+}
+
+export default class CreateCommand extends BaseIPCCommand {
+	static strict = false;
+	static description = 'Creates a transaction which can be broadcasted to the network.';
+
+	static args = [
+		{
+			name: 'networkIdentifier',
+			required: true,
+			description:
+				'Network identifier defined for the network or main | test for the Lisk Network.',
+		},
+		{
+			name: 'fee',
+			required: true,
+			description: 'Transaction fee in LSK.',
+		},
+		{
+			name: 'nonce',
+			required: true,
+			description: 'Nonce of the transaction.',
+		},
+		{
+			name: 'type',
+			required: true,
+			description: 'Register transaction type.',
+		},
+	];
+
+	static examples = [
+		'transaction:create 1 100 8 5I/riNtbXPWtcdk83NHYebbV7Rh6NrAALMNODvmIMlU= --asset=\'{"amount":100,"recipientAddress":"qwBBp9P3ssKQtbg01Gvce364WBU=","data":"send token"}\'',
+		'transaction:create 1 100 8 5I/riNtbXPWtcdk83NHYebbV7Rh6NrAALMNODvmIMlU=',
+	];
+
+	static flags = {
+		...BaseIPCCommand.flags,
+		passphrase: flagParser.string(commonFlags.passphrase),
+		'no-signature': flagParser.boolean({
+			description:
+				'Creates the transaction without a signature. Your passphrase will therefore not be required',
+		}),
+		'sender-publickey': flagParser.string({
+			char: 's',
+			description:
+				'Creates the transaction with provided sender publickey, when passphrase is not provided',
+		}),
+		asset: flagParser.string({
+			char: 'a',
+			description: 'Creates transaction with specific asset information',
+		}),
+		json: flagParser.boolean({
+			char: 'j',
+			description: 'Print the transaction in JSON format',
+		}),
+	};
+
+	async run(): Promise<void> {
+		const {
+			args,
+			flags: {
+				passphrase: passphraseSource,
+				'no-signature': noSignature,
+				'sender-publickey': senderPublicKeySource,
+				asset: assetSource,
+				json,
+			},
+		} = this.parse(CreateCommand);
+		const { fee, nonce, networkIdentifier, type } = args as Args;
+		const assetSchema = this._schema.transactionsAssets[type];
+
+		if (!assetSchema) {
+			throw new Error(`Transaction type:${type} is not registered in the application`);
+		}
+		const rawAsset = assetSource
+			? JSON.parse(assetSource)
+			: await getAssetFromPrompt(assetSchema, []);
+
+		// Validate asset
+		const assetObject = codec.fromJSON(assetSchema, rawAsset);
+		const assetErrors = validator.validator.validate(assetSchema, assetObject);
+		if (assetErrors.length) {
+			throw new LiskValidationError([...assetErrors]);
+		}
+
+		const incompleteTransaction: Record<string, unknown> = {
+			type: Number(type),
+			nonce,
+			fee,
+			senderPublicKey: senderPublicKeySource,
+			asset: assetObject,
+			signatures: [],
+		};
+		let passphrase = '';
+
+		if (passphraseSource || !noSignature) {
+			passphrase = passphraseSource ?? (await getPassphraseFromPrompt('passphrase', true));
+			const { publicKey } = cryptography.getAddressAndPublicKeyFromPassphrase(passphrase);
+			incompleteTransaction.senderPublicKey = publicKey.toString('base64');
+		}
+
+		// Validate transaction
+		let transactionObject = this._codec.transactionObject(incompleteTransaction, assetSchema);
+		const transactionErrors = validator.validator.validate(
+			this._schema.baseTransaction,
+			transactionObject,
+		);
+		if (transactionErrors.length) {
+			throw new LiskValidationError([...transactionErrors]);
+		}
+
+		// Sign transaction
+		if (passphrase) {
+			if (transactionObject.type === 12) {
+				transactionObject = transactions.signMultiSignatureTransaction(
+					assetSchema,
+					{ ...transactionObject },
+					Buffer.from(networkIdentifier, 'hex'),
+					passphrase,
+					assetObject as MultiSignatureKeys,
+				);
+			} else {
+				transactionObject = transactions.signTransaction(
+					assetSchema,
+					{ ...transactionObject },
+					Buffer.from(networkIdentifier, 'hex'),
+					passphrase,
+				);
+			}
+		}
+
+		// Print JSON or encoded transaction bytes
+		if (json) {
+			this.printJSON(codec.toJSON(this._schema.baseTransaction, transactionObject));
+		} else {
+			this.printJSON({
+				transaction: this._codec.encodeTransaction(transactionObject, assetSchema),
+			});
+		}
+	}
+}

--- a/src/commands/transaction/create.ts
+++ b/src/commands/transaction/create.ts
@@ -57,8 +57,8 @@ export default class CreateCommand extends BaseIPCCommand {
 	];
 
 	static examples = [
-		'transaction:create 1 100 8 5I/riNtbXPWtcdk83NHYebbV7Rh6NrAALMNODvmIMlU= --asset=\'{"amount":100,"recipientAddress":"qwBBp9P3ssKQtbg01Gvce364WBU=","data":"send token"}\'',
-		'transaction:create 1 100 8 5I/riNtbXPWtcdk83NHYebbV7Rh6NrAALMNODvmIMlU=',
+		'transaction:create hz2oWizucNpjHZCw8X+tqMOsm4OyYT9Mpf3dN00QNLM= 100000000 2 8 --asset=\'{"amount":100,"recipientAddress":"qwBBp9P3ssKQtbg01Gvce364WBU=","data":"send token"}\'',
+		'transaction:create hz2oWizucNpjHZCw8X+tqMOsm4OyYT9Mpf3dN00QNLM= 100000000 2 8',
 	];
 
 	static flags = {
@@ -111,6 +111,10 @@ export default class CreateCommand extends BaseIPCCommand {
 			throw new LiskValidationError([...assetErrors]);
 		}
 
+		if (!senderPublicKeySource && noSignature) {
+			throw new Error('Sender publickey must be specified when no-signature flags is used');
+		}
+
 		const incompleteTransaction: Record<string, unknown> = {
 			type: Number(type),
 			nonce,
@@ -150,9 +154,13 @@ export default class CreateCommand extends BaseIPCCommand {
 		if (json) {
 			this.printJSON({ ...codec.toJSON(this._schema.baseTransaction, transactionObject) });
 		} else {
-			transactionObject.id = cryptography.hash(this._codec.encodeTransaction(transactionObject, assetSchema));
+			transactionObject.id = cryptography.hash(
+				this._codec.encodeTransaction(transactionObject, assetSchema),
+			);
 			this.printJSON({
-				transaction: this._codec.encodeTransaction(transactionObject, assetSchema).toString('base64'),
+				transaction: this._codec
+					.encodeTransaction(transactionObject, assetSchema)
+					.toString('base64'),
 			});
 		}
 	}

--- a/src/commands/transaction/create.ts
+++ b/src/commands/transaction/create.ts
@@ -30,7 +30,7 @@ interface Args {
 
 export default class CreateCommand extends BaseIPCCommand {
 	static strict = false;
-	static description = 'Creates a transaction which can be broadcasted to the network.';
+	static description = 'Creates a transaction which can be broadcasted to the network. Note: fee and amount should be in Beddows!!';
 
 	static args = [
 		{
@@ -42,7 +42,7 @@ export default class CreateCommand extends BaseIPCCommand {
 		{
 			name: 'fee',
 			required: true,
-			description: 'Transaction fee in LSK.',
+			description: 'Transaction fee in Beddows.',
 		},
 		{
 			name: 'nonce',
@@ -57,7 +57,7 @@ export default class CreateCommand extends BaseIPCCommand {
 	];
 
 	static examples = [
-		'transaction:create hz2oWizucNpjHZCw8X+tqMOsm4OyYT9Mpf3dN00QNLM= 100000000 2 8 --asset=\'{"amount":100,"recipientAddress":"qwBBp9P3ssKQtbg01Gvce364WBU=","data":"send token"}\'',
+		'transaction:create hz2oWizucNpjHZCw8X+tqMOsm4OyYT9Mpf3dN00QNLM= 100000000 2 8 --asset=\'{"amount":100000000,"recipientAddress":"qwBBp9P3ssKQtbg01Gvce364WBU=","data":"send token"}\'',
 		'transaction:create hz2oWizucNpjHZCw8X+tqMOsm4OyYT9Mpf3dN00QNLM= 100000000 2 8',
 	];
 
@@ -132,7 +132,7 @@ export default class CreateCommand extends BaseIPCCommand {
 		}
 
 		// Validate transaction
-		let transactionObject = this._codec.transactionObject(incompleteTransaction, assetSchema);
+		let transactionObject = this._codec.transactionToJSON(incompleteTransaction, assetSchema);
 		const transactionErrors = validator.validator.validate(
 			this._schema.baseTransaction,
 			transactionObject,

--- a/src/commands/transaction/create.ts
+++ b/src/commands/transaction/create.ts
@@ -30,7 +30,8 @@ interface Args {
 
 export default class CreateCommand extends BaseIPCCommand {
 	static strict = false;
-	static description = 'Creates a transaction which can be broadcasted to the network. Note: fee and amount should be in Beddows!!';
+	static description =
+		'Creates a transaction which can be broadcasted to the network. Note: fee and amount should be in Beddows!!';
 
 	static args = [
 		{
@@ -100,11 +101,7 @@ export default class CreateCommand extends BaseIPCCommand {
 		if (!assetSchema) {
 			throw new Error(`Transaction type:${type} is not registered in the application`);
 		}
-		const rawAsset = assetSource
-			? JSON.parse(assetSource)
-			: await getAssetFromPrompt(assetSchema, []);
-
-		// Validate asset
+		const rawAsset = assetSource ? JSON.parse(assetSource) : await getAssetFromPrompt(assetSchema);
 		const assetObject = codec.fromJSON(assetSchema, rawAsset);
 		const assetErrors = validator.validator.validate(assetSchema, assetObject);
 		if (assetErrors.length) {
@@ -131,9 +128,8 @@ export default class CreateCommand extends BaseIPCCommand {
 			incompleteTransaction.senderPublicKey = publicKey.toString('base64');
 		}
 
-		// Validate transaction
-		let transactionObject = this._codec.transactionFromJSON(assetSchema, {
-			...incompleteTransaction
+		const transactionObject = this._codec.transactionFromJSON(assetSchema, {
+			...incompleteTransaction,
 		});
 
 		const transactionErrors = validator.validator.validate(
@@ -144,7 +140,6 @@ export default class CreateCommand extends BaseIPCCommand {
 			throw new LiskValidationError([...transactionErrors]);
 		}
 
-		// Sign transaction
 		transactionObject.asset = assetObject;
 		if (passphrase) {
 			transactions.signTransaction(
@@ -154,13 +149,12 @@ export default class CreateCommand extends BaseIPCCommand {
 				passphrase,
 			);
 		}
-		// Print JSON or encoded transaction bytes
+
 		if (json) {
 			this.printJSON(this._codec.transactionToJSON(assetSchema, transactionObject));
 		} else {
 			this.printJSON({
-				transaction: this._codec
-					.encodeTransaction(assetSchema, transactionObject),
+				transaction: this._codec.encodeTransaction(assetSchema, transactionObject),
 			});
 		}
 	}

--- a/src/commands/transaction/send.ts
+++ b/src/commands/transaction/send.ts
@@ -16,7 +16,7 @@ import { validator } from 'lisk-sdk';
 import BaseIPCCommand from '../../base_ipc';
 
 export default class SendCommand extends BaseIPCCommand {
-	static description = 'Send a transaction to the network.';
+	static description = 'Send a transaction to the local node.';
 	static flags = {
 		...BaseIPCCommand.flags,
 	};

--- a/src/commands/transaction/send.ts
+++ b/src/commands/transaction/send.ts
@@ -16,6 +16,7 @@ import { validator } from 'lisk-sdk';
 import BaseIPCCommand from '../../base_ipc';
 
 export default class SendCommand extends BaseIPCCommand {
+	static description = 'Send a transaction to the network.';
 	static flags = {
 		...BaseIPCCommand.flags,
 	};
@@ -26,6 +27,10 @@ export default class SendCommand extends BaseIPCCommand {
 			required: true,
 			description: 'The transaction to be sent to the node encoded as base64 string',
 		},
+	];
+
+	static examples = [
+		'transaction:send CAgQARiAyrXuASIg/QYbkUZpHzxWUEvgURddW3bRsdAXnFxDcOGFNMWIISIqJAhkEhSrAEGn0/eywpC1uDTUa9x7frhYFRoKc2VuZCB0b2tlbjJAKO3TYBzcNaQbsjQVoNnzw+nPGI2Zca3xh0LOo51YqoSAmqh7z+b+qsRiEcgEcq2Sl/2HcncJ9dfntBNMrxBrAg==',
 	];
 
 	async run(): Promise<void> {

--- a/src/utils/reader.ts
+++ b/src/utils/reader.ts
@@ -120,7 +120,10 @@ const getNestedPropertyTemplate = (schema: Schema): NestedPropertyTemplate => {
 const castValue = (strVal: string): number | string =>
 	Number.isInteger(Number(strVal)) ? Number(strVal) : strVal;
 
-export const transformAsset = (data: Record<string, string>, schema: Schema): Record<string, string> => {
+export const transformAsset = (
+	schema: Schema,
+	data: Record<string, string>,
+): Record<string, string> => {
 	const propertySchema = Object.values(schema.properties);
 
 	return Object.entries(data).reduce((acc, curr, index) => {
@@ -132,7 +135,10 @@ export const transformAsset = (data: Record<string, string>, schema: Schema): Re
 	}, {});
 };
 
-export const transformNestedAsset = (data: Array<Record<string, string>>, schema: Schema): NestedAsset => {
+export const transformNestedAsset = (
+	schema: Schema,
+	data: Array<Record<string, string>>,
+): NestedAsset => {
 	const template = getNestedPropertyTemplate(schema);
 	const result = {};
 	const items: Array<Record<string, string>> = [];
@@ -153,9 +159,7 @@ export const prepareQuestions = (schema: Schema): Question[] => {
 	const keyValEntries = Object.entries(schema.properties);
 	const questions: Question[] = [];
 
-	// eslint-disable-next-line @typescript-eslint/prefer-for-of
-	for (let i = 0; i < keyValEntries.length; i += 1) {
-		const [schemaPropertyName, schemaPropertyValue] = keyValEntries[i];
+	for (const [schemaPropertyName, schemaPropertyValue] of keyValEntries) {
 		if ((schemaPropertyValue as PropertyValue).type === 'array') {
 			let commaSeparatedKeys: string[] = [];
 			// nested items properties
@@ -189,7 +193,7 @@ export const prepareQuestions = (schema: Schema): Question[] => {
 
 export const getAssetFromPrompt = async (
 	assetSchema: Schema,
-	output: Array<{ [key: string]: string }>,
+	output: Array<{ [key: string]: string }> = [],
 ): Promise<NestedAsset | Record<string, unknown>> => {
 	// prepare array of questions based on asset schema
 	const questions = prepareQuestions(assetSchema);
@@ -209,6 +213,6 @@ export const getAssetFromPrompt = async (
 
 	// transform asset prompt result according to asset schema
 	return isTypeConfirm
-		? transformNestedAsset(filteredResult, assetSchema)
-		: transformAsset(result, assetSchema);
+		? transformNestedAsset(assetSchema, filteredResult)
+		: transformAsset(assetSchema, result);
 };

--- a/test/commands/transaction/create.spec.ts
+++ b/test/commands/transaction/create.spec.ts
@@ -25,10 +25,13 @@ import * as readerUtils from '../../../src/utils/reader';
 
 const transactionsAssets = {
 	8: transactions.TransferTransaction.ASSET_SCHEMA,
+	13: transactions.VoteTransaction.ASSET_SCHEMA,
 };
 const passphrase = 'peanut hundred pen hawk invite exclude brain chunk gadget wait wrong ready';
 const transferAsset =
 	'{"amount":100,"recipientAddress":"qwBBp9P3ssKQtbg01Gvce364WBU=","data":"send token"}';
+const voteAsset =
+	'{"votes":[{"delegateAddress":"qwBBp9P3ssKQtbg01Gvce364WBU=","amount":100},{"delegateAddress":"qwBBp9P3ssKQtbg01Gvce364WBU=","amount":-50}]}';
 const { publicKey } = cryptography.getAddressAndPublicKeyFromPassphrase(passphrase);
 const senderPublickey = publicKey.toString('base64');
 
@@ -37,13 +40,11 @@ describe('transaction:create command', () => {
 	const printJSONStub = sandbox.stub();
 	const ipcInvokeStub = sandbox.stub();
 	const ipcStartAndListenStub = sandbox.stub();
-	const promptAssetStub = sandbox
-		.stub()
-		.resolves({
-			amount: 100,
-			recipientAddress: 'qwBBp9P3ssKQtbg01Gvce364WBU=',
-			data: 'send token',
-		});
+	const promptAssetStub = sandbox.stub().resolves({
+		amount: 100,
+		recipientAddress: 'qwBBp9P3ssKQtbg01Gvce364WBU=',
+		data: 'send token',
+	});
 
 	ipcInvokeStub.withArgs('app:getSchema').resolves({
 		baseTransaction: transactions.BaseTransaction.BASE_SCHEMA,
@@ -196,6 +197,46 @@ describe('transaction:create command', () => {
 					});
 				});
 		});
+
+		describe(`transaction:create hz2oWizucNpjHZCw8X+tqMOsm4OyYT9Mpf3dN00QNLM= 100000000 2 8 --asset=${voteAsset} --passphrase=${passphrase}`, () => {
+			setupTest()
+				.command([
+					'transaction:create',
+					'hz2oWizucNpjHZCw8X+tqMOsm4OyYT9Mpf3dN00QNLM=',
+					'100000000',
+					'2',
+					'13',
+					`--asset=${voteAsset}`,
+					`--passphrase=${passphrase}`,
+				])
+				.it('should return encoded transaction string in base64 format with signature', () => {
+					expect(printJSONStub).to.be.calledOnce;
+					expect(printJSONStub).to.be.calledWithExactly({
+						transaction:
+							'CA0QAhiAwtcvIiAP6aPxohtVMPJ/h6QUtUnnmpQL8k/fKy8F5/Iq7uzIaio1ChkKFKsAQafT97LCkLW4NNRr3Ht+uFgVEMgBChgKFKsAQafT97LCkLW4NNRr3Ht+uFgVEGMyQGXYV+1Eua7EMUHG5W5HjrfIQxYd2VLC/nsnC2tSKfeE8pKSzzr0lqr9fwwHbLdDBOS2rr8QC7r0NOitdQn6wQw=',
+					});
+				});
+		});
+
+		describe(`transaction:create hz2oWizucNpjHZCw8X+tqMOsm4OyYT9Mpf3dN00QNLM= 100000000 2 8 --asset=${voteAsset} --passphrase=${passphrase}`, () => {
+			setupTest()
+				.command([
+					'transaction:create',
+					'hz2oWizucNpjHZCw8X+tqMOsm4OyYT9Mpf3dN00QNLM=',
+					'100000000',
+					'2',
+					'13',
+					`--asset=${voteAsset}`,
+					`--passphrase=${passphrase}`,
+				])
+				.it('should return encoded transaction string in base64 format with signature', () => {
+					expect(printJSONStub).to.be.calledOnce;
+					expect(printJSONStub).to.be.calledWithExactly({
+						transaction:
+							'CA0QAhiAwtcvIiAP6aPxohtVMPJ/h6QUtUnnmpQL8k/fKy8F5/Iq7uzIaio1ChkKFKsAQafT97LCkLW4NNRr3Ht+uFgVEMgBChgKFKsAQafT97LCkLW4NNRr3Ht+uFgVEGMyQGXYV+1Eua7EMUHG5W5HjrfIQxYd2VLC/nsnC2tSKfeE8pKSzzr0lqr9fwwHbLdDBOS2rr8QC7r0NOitdQn6wQw=',
+					});
+				});
+		});
 	});
 
 	describe('transaction:create with prompts and flags', () => {
@@ -280,9 +321,9 @@ describe('transaction:create command', () => {
 							fee: '100000000',
 							senderPublicKey: 'D+mj8aIbVTDyf4ekFLVJ55qUC/JP3ysvBefyKu7syGo=',
 							asset: {
-								amount: "100",
-								data: "send token",
-								recipientAddress: "qwBBp9P3ssKQtbg01Gvce364WBU="
+								amount: '100',
+								data: 'send token',
+								recipientAddress: 'qwBBp9P3ssKQtbg01Gvce364WBU=',
 							},
 							signatures: [],
 						});
@@ -310,9 +351,9 @@ describe('transaction:create command', () => {
 						fee: '100000000',
 						senderPublicKey: 'D+mj8aIbVTDyf4ekFLVJ55qUC/JP3ysvBefyKu7syGo=',
 						asset: {
-							amount: "100",
-							data: "send token",
-							recipientAddress: "qwBBp9P3ssKQtbg01Gvce364WBU="
+							amount: '100',
+							data: 'send token',
+							recipientAddress: 'qwBBp9P3ssKQtbg01Gvce364WBU=',
 						},
 						signatures: [
 							'hxRCH+EoCnq1BQXU+IIzA3cZqrHwgV4oaJxe/5zZxV9DmAF7SF8RtCyYIBdSsVfMYR8OX82tt23og+OuQkeaAw==',

--- a/test/commands/transaction/create.spec.ts
+++ b/test/commands/transaction/create.spec.ts
@@ -171,7 +171,7 @@ describe('transaction:create command', () => {
 					expect(printJSONStub).to.be.calledOnce;
 					expect(printJSONStub).to.be.calledWithExactly({
 						transaction:
-							'CAgQAhiAwtcvIiAP6aPxohtVMPJ/h6QUtUnnmpQL8k/fKy8F5/Iq7uzIaiokCGQSFKsAQafT97LCkLW4NNRr3Ht+uFgVGgpzZW5kIHRva2VuMkBW4g5n/J9XouRbWtVfMucUkhy1FOp5Gmz1Bz4ZT7/2IOCZhl7FLPTvjjRoclnyECIO3B4YK2C9kYTqwzbvKS0B',
+							'CAgQAhiAwtcvIiAP6aPxohtVMPJ/h6QUtUnnmpQL8k/fKy8F5/Iq7uzIaiokCGQSFKsAQafT97LCkLW4NNRr3Ht+uFgVGgpzZW5kIHRva2VuMkCHFEIf4SgKerUFBdT4gjMDdxmqsfCBXihonF7/nNnFX0OYAXtIXxG0LJggF1KxV8xhHw5fza23beiD465CR5oD',
 					});
 				});
 		});
@@ -223,7 +223,7 @@ describe('transaction:create command', () => {
 					expect(printJSONStub).to.be.calledOnce;
 					expect(printJSONStub).to.be.calledWithExactly({
 						transaction:
-							'CAgQAhiAwtcvIiAP6aPxohtVMPJ/h6QUtUnnmpQL8k/fKy8F5/Iq7uzIaiokCGQSFKsAQafT97LCkLW4NNRr3Ht+uFgVGgpzZW5kIHRva2VuMkBW4g5n/J9XouRbWtVfMucUkhy1FOp5Gmz1Bz4ZT7/2IOCZhl7FLPTvjjRoclnyECIO3B4YK2C9kYTqwzbvKS0B',
+							'CAgQAhiAwtcvIiAP6aPxohtVMPJ/h6QUtUnnmpQL8k/fKy8F5/Iq7uzIaiokCGQSFKsAQafT97LCkLW4NNRr3Ht+uFgVGgpzZW5kIHRva2VuMkCHFEIf4SgKerUFBdT4gjMDdxmqsfCBXihonF7/nNnFX0OYAXtIXxG0LJggF1KxV8xhHw5fza23beiD465CR5oD',
 					});
 				});
 		});
@@ -252,7 +252,7 @@ describe('transaction:create command', () => {
 					expect(printJSONStub).to.be.calledOnce;
 					expect(printJSONStub).to.be.calledWithExactly({
 						transaction:
-							'CAgQAhiAwtcvIiAP6aPxohtVMPJ/h6QUtUnnmpQL8k/fKy8F5/Iq7uzIaiokCGQSFKsAQafT97LCkLW4NNRr3Ht+uFgVGgpzZW5kIHRva2VuMkBW4g5n/J9XouRbWtVfMucUkhy1FOp5Gmz1Bz4ZT7/2IOCZhl7FLPTvjjRoclnyECIO3B4YK2C9kYTqwzbvKS0B',
+							'CAgQAhiAwtcvIiAP6aPxohtVMPJ/h6QUtUnnmpQL8k/fKy8F5/Iq7uzIaiokCGQSFKsAQafT97LCkLW4NNRr3Ht+uFgVGgpzZW5kIHRva2VuMkCHFEIf4SgKerUFBdT4gjMDdxmqsfCBXihonF7/nNnFX0OYAXtIXxG0LJggF1KxV8xhHw5fza23beiD465CR5oD',
 					});
 				});
 		});
@@ -279,7 +279,11 @@ describe('transaction:create command', () => {
 							nonce: '2',
 							fee: '100000000',
 							senderPublicKey: 'D+mj8aIbVTDyf4ekFLVJ55qUC/JP3ysvBefyKu7syGo=',
-							asset: 'CGQSFKsAQafT97LCkLW4NNRr3Ht+uFgVGgpzZW5kIHRva2Vu',
+							asset: {
+								amount: "100",
+								data: "send token",
+								recipientAddress: "qwBBp9P3ssKQtbg01Gvce364WBU="
+							},
 							signatures: [],
 						});
 					},
@@ -305,9 +309,13 @@ describe('transaction:create command', () => {
 						nonce: '2',
 						fee: '100000000',
 						senderPublicKey: 'D+mj8aIbVTDyf4ekFLVJ55qUC/JP3ysvBefyKu7syGo=',
-						asset: 'CGQSFKsAQafT97LCkLW4NNRr3Ht+uFgVGgpzZW5kIHRva2Vu',
+						asset: {
+							amount: "100",
+							data: "send token",
+							recipientAddress: "qwBBp9P3ssKQtbg01Gvce364WBU="
+						},
 						signatures: [
-							'VuIOZ/yfV6LkW1rVXzLnFJIctRTqeRps9Qc+GU+/9iDgmYZexSz07440aHJZ8hAiDtweGCtgvZGE6sM27yktAQ==',
+							'hxRCH+EoCnq1BQXU+IIzA3cZqrHwgV4oaJxe/5zZxV9DmAF7SF8RtCyYIBdSsVfMYR8OX82tt23og+OuQkeaAw==',
 						],
 					});
 				});

--- a/test/commands/transaction/create.spec.ts
+++ b/test/commands/transaction/create.spec.ts
@@ -22,11 +22,9 @@ import { cryptography, IPCChannel, transactions } from 'lisk-sdk';
 import baseIPC from '../../../src/base_ipc';
 import * as appUtils from '../../../src/utils/application';
 import * as readerUtils from '../../../src/utils/reader';
-import { transferAssetSchema } from '../../utils/transactions';
-import { getAssetFromPrompt } from '../../../src/utils/reader';
 
 const transactionsAssets = {
-	8: transferAssetSchema,
+	8: transactions.TransferTransaction.ASSET_SCHEMA,
 };
 const passphrase = 'peanut hundred pen hawk invite exclude brain chunk gadget wait wrong ready';
 const transferAsset =
@@ -34,7 +32,7 @@ const transferAsset =
 const { publicKey } = cryptography.getAddressAndPublicKeyFromPassphrase(passphrase);
 const senderPublickey = publicKey.toString('base64');
 
-describe.only('transaction:create command', () => {
+describe('transaction:create command', () => {
 	const fsStub = sandbox.stub().returns(true);
 	const printJSONStub = sandbox.stub();
 	const ipcInvokeStub = sandbox.stub();

--- a/test/commands/transaction/create.spec.ts
+++ b/test/commands/transaction/create.spec.ts
@@ -1,0 +1,318 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+
+import { expect, test } from '@oclif/test';
+import * as sandbox from 'sinon';
+import * as fs from 'fs-extra';
+import * as inquirer from 'inquirer';
+import { cryptography, IPCChannel, transactions } from 'lisk-sdk';
+
+import baseIPC from '../../../src/base_ipc';
+import * as appUtils from '../../../src/utils/application';
+import * as readerUtils from '../../../src/utils/reader';
+import { transferAssetSchema } from '../../utils/transactions';
+import { getAssetFromPrompt } from '../../../src/utils/reader';
+
+const transactionsAssets = {
+	8: transferAssetSchema,
+};
+const passphrase = 'peanut hundred pen hawk invite exclude brain chunk gadget wait wrong ready';
+const transferAsset =
+	'{"amount":100,"recipientAddress":"qwBBp9P3ssKQtbg01Gvce364WBU=","data":"send token"}';
+const { publicKey } = cryptography.getAddressAndPublicKeyFromPassphrase(passphrase);
+const senderPublickey = publicKey.toString('base64');
+
+describe.only('transaction:create command', () => {
+	const fsStub = sandbox.stub().returns(true);
+	const printJSONStub = sandbox.stub();
+	const ipcInvokeStub = sandbox.stub();
+	const ipcStartAndListenStub = sandbox.stub();
+	const promptAssetStub = sandbox
+		.stub()
+		.resolves({
+			amount: 100,
+			recipientAddress: 'qwBBp9P3ssKQtbg01Gvce364WBU=',
+			data: 'send token',
+		});
+
+	ipcInvokeStub.withArgs('app:getSchema').resolves({
+		baseTransaction: transactions.BaseTransaction.BASE_SCHEMA,
+		transactionsAssets,
+	});
+
+	afterEach(() => {
+		ipcInvokeStub.resetHistory();
+		printJSONStub.resetHistory();
+		ipcStartAndListenStub.resetHistory();
+		promptAssetStub.resetHistory();
+	});
+
+	const setupTest = () =>
+		test
+			.stub(appUtils, 'isApplicationRunning', sandbox.stub().returns(true))
+			.stub(fs, 'existsSync', fsStub)
+			.stub(baseIPC.prototype, 'printJSON', printJSONStub)
+			.stub(IPCChannel.prototype, 'startAndListen', ipcStartAndListenStub)
+			.stub(IPCChannel.prototype, 'invoke', ipcInvokeStub)
+			.stub(inquirer, 'prompt', promptAssetStub)
+			.stub(readerUtils, 'getPassphraseFromPrompt', sandbox.stub().resolves(passphrase))
+			.stdout()
+			.stderr();
+
+	describe('transaction:create', () => {
+		setupTest()
+			.command(['transaction:create'])
+			.catch((error: Error) => expect(error.message).to.contain('Missing 4 required args:'))
+			.it('should throw an error when no arguments are provided.');
+	});
+
+	describe('transaction:create hz2oWizucNpjHZCw8X+tqMOsm4OyYT9Mpf3dN00QNLM=', () => {
+		setupTest()
+			.command(['transaction:create', 'hz2oWizucNpjHZCw8X+tqMOsm4OyYT9Mpf3dN00QNLM='])
+			.catch((error: Error) => expect(error.message).to.contain('Missing 3 required args:'))
+			.it('should throw an error when fee, nonce and transaction type are provided.');
+	});
+
+	describe('transaction:create hz2oWizucNpjHZCw8X+tqMOsm4OyYT9Mpf3dN00QNLM= 100000000', () => {
+		setupTest()
+			.command(['transaction:create', 'hz2oWizucNpjHZCw8X+tqMOsm4OyYT9Mpf3dN00QNLM=', '100000000'])
+			.catch((error: Error) => expect(error.message).to.contain('Missing 2 required args:'))
+			.it('should throw an error when nonce and transaction type are provided.');
+	});
+
+	describe('transaction:create hz2oWizucNpjHZCw8X+tqMOsm4OyYT9Mpf3dN00QNLM= 100000000 2', () => {
+		setupTest()
+			.command([
+				'transaction:create',
+				'hz2oWizucNpjHZCw8X+tqMOsm4OyYT9Mpf3dN00QNLM=',
+				'100000000',
+				'2',
+			])
+			.catch((error: Error) => expect(error.message).to.contain('Missing 1 required arg:'))
+			.it('should throw an error when transaction type are provided.');
+	});
+
+	describe('transaction:create hz2oWizucNpjHZCw8X+tqMOsm4OyYT9Mpf3dN00QNLM= 100000000 2 99999', () => {
+		setupTest()
+			.command([
+				'transaction:create',
+				'hz2oWizucNpjHZCw8X+tqMOsm4OyYT9Mpf3dN00QNLM=',
+				'100000000',
+				'2',
+				'99999',
+			])
+			.catch((error: Error) =>
+				expect(error.message).to.contain(
+					'Transaction type:99999 is not registered in the application',
+				),
+			)
+			.it('should throw an error when transaction type is unknown.');
+	});
+
+	describe('transaction:create with flags', () => {
+		describe(`transaction:create hz2oWizucNpjHZCw8X+tqMOsm4OyYT9Mpf3dN00QNLM= 100000000 2 8 --asset='{"amount": "abc"}' --passphrase=${passphrase}`, () => {
+			setupTest()
+				.command([
+					'transaction:create',
+					'hz2oWizucNpjHZCw8X+tqMOsm4OyYT9Mpf3dN00QNLM=',
+					'100000000',
+					'2',
+					'8',
+					'--asset={"amount": "abc"}',
+					`--passphrase=${passphrase}`,
+				])
+				.catch((error: Error) => expect(error.message).to.contain('Cannot convert abc to a BigInt'))
+				.it('should throw error for invalid asset.');
+		});
+
+		describe(`transaction:create hz2oWizucNpjHZCw8X+tqMOsm4OyYT9Mpf3dN00QNLM= 100000000 2 8 --asset=${transferAsset} --no-signature`, () => {
+			setupTest()
+				.command([
+					'transaction:create',
+					'hz2oWizucNpjHZCw8X+tqMOsm4OyYT9Mpf3dN00QNLM=',
+					'100000000',
+					'2',
+					'8',
+					`--asset=${transferAsset}`,
+					'--no-signature',
+				])
+				.catch((error: Error) =>
+					expect(error.message).to.contain(
+						'Sender publickey must be specified when no-signature flags is used',
+					),
+				)
+				.it(
+					'should throw error when sender publickey not specified when no-signature flag is used.',
+				);
+		});
+
+		describe(`transaction:create hz2oWizucNpjHZCw8X+tqMOsm4OyYT9Mpf3dN00QNLM= 100000000 2 8 --asset=${transferAsset} --passphrase=${passphrase}`, () => {
+			setupTest()
+				.command([
+					'transaction:create',
+					'hz2oWizucNpjHZCw8X+tqMOsm4OyYT9Mpf3dN00QNLM=',
+					'100000000',
+					'2',
+					'8',
+					`--asset=${transferAsset}`,
+					`--passphrase=${passphrase}`,
+				])
+				.it('should return encoded transaction string in base64 format with signature', () => {
+					expect(printJSONStub).to.be.calledOnce;
+					expect(printJSONStub).to.be.calledWithExactly({
+						transaction:
+							'CAgQAhiAwtcvIiAP6aPxohtVMPJ/h6QUtUnnmpQL8k/fKy8F5/Iq7uzIaiokCGQSFKsAQafT97LCkLW4NNRr3Ht+uFgVGgpzZW5kIHRva2VuMkBW4g5n/J9XouRbWtVfMucUkhy1FOp5Gmz1Bz4ZT7/2IOCZhl7FLPTvjjRoclnyECIO3B4YK2C9kYTqwzbvKS0B',
+					});
+				});
+		});
+
+		describe(`transaction:create hz2oWizucNpjHZCw8X+tqMOsm4OyYT9Mpf3dN00QNLM= 100000000 2 8 --asset=${transferAsset} --no-signature --sender-publickey=${senderPublickey}`, () => {
+			setupTest()
+				.command([
+					'transaction:create',
+					'hz2oWizucNpjHZCw8X+tqMOsm4OyYT9Mpf3dN00QNLM=',
+					'100000000',
+					'2',
+					'8',
+					`--asset=${transferAsset}`,
+					'--no-signature',
+					`--sender-publickey=${senderPublickey}`,
+				])
+				.it('should return encoded transaction string in base64 format without signature', () => {
+					expect(printJSONStub).to.be.calledOnce;
+					expect(printJSONStub).to.be.calledWithExactly({
+						transaction:
+							'CAgQAhiAwtcvIiAP6aPxohtVMPJ/h6QUtUnnmpQL8k/fKy8F5/Iq7uzIaiokCGQSFKsAQafT97LCkLW4NNRr3Ht+uFgVGgpzZW5kIHRva2Vu',
+					});
+				});
+		});
+	});
+
+	describe('transaction:create with prompts and flags', () => {
+		describe(`transaction:create hz2oWizucNpjHZCw8X+tqMOsm4OyYT9Mpf3dN00QNLM= 100000000 2 8 --passphrase=${passphrase}`, () => {
+			setupTest()
+				.command([
+					'transaction:create',
+					'hz2oWizucNpjHZCw8X+tqMOsm4OyYT9Mpf3dN00QNLM=',
+					'100000000',
+					'2',
+					'8',
+					`--passphrase=${passphrase}`,
+				])
+				.it('should prompt user for asset.', () => {
+					expect(promptAssetStub).to.be.calledOnce;
+					expect(promptAssetStub).to.be.calledWithExactly([
+						{ message: 'Please enter: amount: ', name: 'amount', type: 'input' },
+						{
+							message: 'Please enter: recipientAddress: ',
+							name: 'recipientAddress',
+							type: 'input',
+						},
+						{ message: 'Please enter: data: ', name: 'data', type: 'input' },
+					]);
+					expect(printJSONStub).to.be.calledOnce;
+					expect(printJSONStub).to.be.calledWithExactly({
+						transaction:
+							'CAgQAhiAwtcvIiAP6aPxohtVMPJ/h6QUtUnnmpQL8k/fKy8F5/Iq7uzIaiokCGQSFKsAQafT97LCkLW4NNRr3Ht+uFgVGgpzZW5kIHRva2VuMkBW4g5n/J9XouRbWtVfMucUkhy1FOp5Gmz1Bz4ZT7/2IOCZhl7FLPTvjjRoclnyECIO3B4YK2C9kYTqwzbvKS0B',
+					});
+				});
+		});
+
+		describe('transaction:create hz2oWizucNpjHZCw8X+tqMOsm4OyYT9Mpf3dN00QNLM= 100000000 2 8', () => {
+			setupTest()
+				.command([
+					'transaction:create',
+					'hz2oWizucNpjHZCw8X+tqMOsm4OyYT9Mpf3dN00QNLM=',
+					'100000000',
+					'2',
+					'8',
+				])
+				.it('should prompt user for asset and passphrase.', () => {
+					expect(promptAssetStub).to.be.calledOnce;
+					expect(promptAssetStub).to.be.calledWithExactly([
+						{ message: 'Please enter: amount: ', name: 'amount', type: 'input' },
+						{
+							message: 'Please enter: recipientAddress: ',
+							name: 'recipientAddress',
+							type: 'input',
+						},
+						{ message: 'Please enter: data: ', name: 'data', type: 'input' },
+					]);
+					expect(readerUtils.getPassphraseFromPrompt).to.be.calledWithExactly('passphrase', true);
+					expect(printJSONStub).to.be.calledOnce;
+					expect(printJSONStub).to.be.calledWithExactly({
+						transaction:
+							'CAgQAhiAwtcvIiAP6aPxohtVMPJ/h6QUtUnnmpQL8k/fKy8F5/Iq7uzIaiokCGQSFKsAQafT97LCkLW4NNRr3Ht+uFgVGgpzZW5kIHRva2VuMkBW4g5n/J9XouRbWtVfMucUkhy1FOp5Gmz1Bz4ZT7/2IOCZhl7FLPTvjjRoclnyECIO3B4YK2C9kYTqwzbvKS0B',
+					});
+				});
+		});
+
+		describe(`transaction:create hz2oWizucNpjHZCw8X+tqMOsm4OyYT9Mpf3dN00QNLM= 100000000 2 8 --asset=${transferAsset} --no-signature --json`, () => {
+			setupTest()
+				.command([
+					'transaction:create',
+					'hz2oWizucNpjHZCw8X+tqMOsm4OyYT9Mpf3dN00QNLM=',
+					'100000000',
+					'2',
+					'8',
+					`--asset=${transferAsset}`,
+					'--no-signature',
+					`--sender-publickey=${senderPublickey}`,
+					'--json',
+				])
+				.it(
+					'should return unsigned transaction in json format when no passphrase specified',
+					() => {
+						expect(printJSONStub).to.be.calledOnce;
+						expect(printJSONStub).to.be.calledWithExactly({
+							type: 8,
+							nonce: '2',
+							fee: '100000000',
+							senderPublicKey: 'D+mj8aIbVTDyf4ekFLVJ55qUC/JP3ysvBefyKu7syGo=',
+							asset: 'CGQSFKsAQafT97LCkLW4NNRr3Ht+uFgVGgpzZW5kIHRva2Vu',
+							signatures: [],
+						});
+					},
+				);
+		});
+
+		describe(`transaction:create hz2oWizucNpjHZCw8X+tqMOsm4OyYT9Mpf3dN00QNLM= 100000000 2 8 --asset=${transferAsset} --passphrase=${passphrase} --json`, () => {
+			setupTest()
+				.command([
+					'transaction:create',
+					'hz2oWizucNpjHZCw8X+tqMOsm4OyYT9Mpf3dN00QNLM=',
+					'100000000',
+					'2',
+					'8',
+					`--asset=${transferAsset}`,
+					`--passphrase=${passphrase}`,
+					'--json',
+				])
+				.it('should return signed transaction in json format when passphrase specified', () => {
+					expect(printJSONStub).to.be.calledOnce;
+					expect(printJSONStub).to.be.calledWithExactly({
+						type: 8,
+						nonce: '2',
+						fee: '100000000',
+						senderPublicKey: 'D+mj8aIbVTDyf4ekFLVJ55qUC/JP3ysvBefyKu7syGo=',
+						asset: 'CGQSFKsAQafT97LCkLW4NNRr3Ht+uFgVGgpzZW5kIHRva2Vu',
+						signatures: [
+							'VuIOZ/yfV6LkW1rVXzLnFJIctRTqeRps9Qc+GU+/9iDgmYZexSz07440aHJZ8hAiDtweGCtgvZGE6sM27yktAQ==',
+						],
+					});
+				});
+		});
+	});
+});

--- a/test/commands/transaction/get.spec.ts
+++ b/test/commands/transaction/get.spec.ts
@@ -16,46 +16,11 @@
 import { expect, test } from '@oclif/test';
 import * as sandbox from 'sinon';
 import * as fs from 'fs-extra';
-import { IPCChannel } from 'lisk-sdk';
+import { IPCChannel, transactions } from 'lisk-sdk';
 
 import baseIPC from '../../../src/base_ipc';
 import * as appUtils from '../../../src/utils/application';
 import { createTransferTransaction, encodeTransactionFromJSON } from '../../utils/transactions';
-
-export const baseTransactionSchema = {
-	$id: 'lisk/base-transaction',
-	type: 'object',
-	required: ['type', 'nonce', 'fee', 'senderPublicKey', 'asset'],
-	properties: {
-		type: {
-			dataType: 'uint32',
-			fieldNumber: 1,
-		},
-		nonce: {
-			dataType: 'uint64',
-			fieldNumber: 2,
-		},
-		fee: {
-			dataType: 'uint64',
-			fieldNumber: 3,
-		},
-		senderPublicKey: {
-			dataType: 'bytes',
-			fieldNumber: 4,
-		},
-		asset: {
-			dataType: 'bytes',
-			fieldNumber: 5,
-		},
-		signatures: {
-			type: 'array',
-			items: {
-				dataType: 'bytes',
-			},
-			fieldNumber: 6,
-		},
-	},
-};
 
 const transferAssetSchema = {
 	$id: 'lisk/transfer-transaction',
@@ -95,7 +60,7 @@ describe('transaction:get command', () => {
 	});
 	const encodedTransaction = encodeTransactionFromJSON(
 		transferTransaction as any,
-		baseTransactionSchema,
+		transactions.BaseTransaction.BASE_SCHEMA,
 		transactionsAssets,
 	);
 	const fsStub = sandbox.stub().returns(true);
@@ -105,7 +70,7 @@ describe('transaction:get command', () => {
 	ipcInvokeStub
 		.withArgs('app:getSchema')
 		.resolves({
-			baseTransaction: baseTransactionSchema,
+			baseTransaction: transactions.BaseTransaction.BASE_SCHEMA,
 			transactionsAssets,
 		})
 		.withArgs('app:getTransactionByID', { id: transactionId })
@@ -133,7 +98,7 @@ describe('transaction:get command', () => {
 
 	describe('transaction:get {transactionId}', () => {
 		setupTest()
-			.command(['transaction:get', '6rBsaiLoi8pxUOA0en2Xas0HDLkoRCPm6r7NZXrMEmM='])
+			.command(['transaction:get', transactionId])
 			.it('should get transaction for the given id and display as an object', () => {
 				expect(ipcInvokeStub).to.have.been.calledTwice;
 				expect(ipcInvokeStub).to.have.been.calledWithExactly('app:getSchema');

--- a/test/commands/transaction/prompt.spec.ts
+++ b/test/commands/transaction/prompt.spec.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+
+import { expect } from '@oclif/test';
+import { transactions } from 'lisk-sdk';
+import { prepareQuestions, transformAsset, transformNestedAsset } from '../../../src/utils/reader';
+
+describe('prompt', () => {
+  describe('prepareQuestions', () => {
+    it('should return array of questions for given asset schema', () => {
+      const questions = prepareQuestions(transactions.TransferTransaction.ASSET_SCHEMA);
+      expect(questions).to.deep.equal([
+        { type: 'input', name: 'amount', message: 'Please enter: amount: ' },
+        {
+          type: 'input',
+          name: 'recipientAddress',
+          message: 'Please enter: recipientAddress: '
+        },
+        { type: 'input', name: 'data', message: 'Please enter: data: ' }
+      ]);
+    });
+  });
+
+  describe('transformAsset', () => {
+    it('should transform result according to asset schema', () => {
+      const questions = prepareQuestions(transactions.MultisignatureTransaction.ASSET_SCHEMA);
+      const transformedAsset = transformAsset({
+        'numberOfSignatures': '4',
+        'mandatoryKeys': 'a,b',
+        'optionalKeys': 'c,d'
+      }, transactions.MultisignatureTransaction.ASSET_SCHEMA);
+      expect(questions).to.deep.equal([
+        {
+          type: 'input',
+          name: 'numberOfSignatures',
+          message: 'Please enter: numberOfSignatures: '
+        },
+        {
+          type: 'input',
+          name: 'mandatoryKeys',
+          message: 'Please enter: mandatoryKeys(comma separated values (a,b)): '
+        },
+        {
+          type: 'input',
+          name: 'optionalKeys',
+          message: 'Please enter: optionalKeys(comma separated values (a,b)): '
+        }
+      ]);
+      expect(transformedAsset).to.deep.equal({
+        'numberOfSignatures': 4,
+        'mandatoryKeys': ['a', 'b'],
+        'optionalKeys': ['c', 'd']
+      });
+    });
+  });
+
+  describe('transformNestedAsset', () => {
+    it('should transform result according to nested asset schema', () => {
+      const questions = prepareQuestions(transactions.VoteTransaction.ASSET_SCHEMA);
+      const transformedAsset = transformNestedAsset([{ votes: 'a,100' }, { votes: 'b,300' }], transactions.VoteTransaction.ASSET_SCHEMA);
+
+      expect(questions).to.deep.equal([
+        {
+          type: 'input',
+          name: 'votes',
+          message: 'Please enter: votes(delegateAddress, amount): '
+        },
+        {
+          type: 'confirm',
+          name: 'askAgain',
+          message: 'Want to enter another votes(delegateAddress, amount)'
+        }
+      ]);
+      expect(transformedAsset).to.deep.equal({
+        votes: [
+          { delegateAddress: 'a', amount: 100 },
+          { delegateAddress: 'b', amount: 300 },
+        ]
+      });
+    });
+  });
+});

--- a/test/commands/transaction/prompt.spec.ts
+++ b/test/commands/transaction/prompt.spec.ts
@@ -18,77 +18,80 @@ import { transactions } from 'lisk-sdk';
 import { prepareQuestions, transformAsset, transformNestedAsset } from '../../../src/utils/reader';
 
 describe('prompt', () => {
-  describe('prepareQuestions', () => {
-    it('should return array of questions for given asset schema', () => {
-      const questions = prepareQuestions(transactions.TransferTransaction.ASSET_SCHEMA);
-      expect(questions).to.deep.equal([
-        { type: 'input', name: 'amount', message: 'Please enter: amount: ' },
-        {
-          type: 'input',
-          name: 'recipientAddress',
-          message: 'Please enter: recipientAddress: '
-        },
-        { type: 'input', name: 'data', message: 'Please enter: data: ' }
-      ]);
-    });
-  });
+	describe('prepareQuestions', () => {
+		it('should return array of questions for given asset schema', () => {
+			const questions = prepareQuestions(transactions.TransferTransaction.ASSET_SCHEMA);
+			expect(questions).to.deep.equal([
+				{ type: 'input', name: 'amount', message: 'Please enter: amount: ' },
+				{
+					type: 'input',
+					name: 'recipientAddress',
+					message: 'Please enter: recipientAddress: ',
+				},
+				{ type: 'input', name: 'data', message: 'Please enter: data: ' },
+			]);
+		});
+	});
 
-  describe('transformAsset', () => {
-    it('should transform result according to asset schema', () => {
-      const questions = prepareQuestions(transactions.MultisignatureTransaction.ASSET_SCHEMA);
-      const transformedAsset = transformAsset({
-        'numberOfSignatures': '4',
-        'mandatoryKeys': 'a,b',
-        'optionalKeys': 'c,d'
-      }, transactions.MultisignatureTransaction.ASSET_SCHEMA);
-      expect(questions).to.deep.equal([
-        {
-          type: 'input',
-          name: 'numberOfSignatures',
-          message: 'Please enter: numberOfSignatures: '
-        },
-        {
-          type: 'input',
-          name: 'mandatoryKeys',
-          message: 'Please enter: mandatoryKeys(comma separated values (a,b)): '
-        },
-        {
-          type: 'input',
-          name: 'optionalKeys',
-          message: 'Please enter: optionalKeys(comma separated values (a,b)): '
-        }
-      ]);
-      expect(transformedAsset).to.deep.equal({
-        'numberOfSignatures': 4,
-        'mandatoryKeys': ['a', 'b'],
-        'optionalKeys': ['c', 'd']
-      });
-    });
-  });
+	describe('transformAsset', () => {
+		it('should transform result according to asset schema', () => {
+			const questions = prepareQuestions(transactions.MultisignatureTransaction.ASSET_SCHEMA);
+			const transformedAsset = transformAsset(transactions.MultisignatureTransaction.ASSET_SCHEMA, {
+				numberOfSignatures: '4',
+				mandatoryKeys: 'a,b',
+				optionalKeys: 'c,d',
+			});
+			expect(questions).to.deep.equal([
+				{
+					type: 'input',
+					name: 'numberOfSignatures',
+					message: 'Please enter: numberOfSignatures: ',
+				},
+				{
+					type: 'input',
+					name: 'mandatoryKeys',
+					message: 'Please enter: mandatoryKeys(comma separated values (a,b)): ',
+				},
+				{
+					type: 'input',
+					name: 'optionalKeys',
+					message: 'Please enter: optionalKeys(comma separated values (a,b)): ',
+				},
+			]);
+			expect(transformedAsset).to.deep.equal({
+				numberOfSignatures: 4,
+				mandatoryKeys: ['a', 'b'],
+				optionalKeys: ['c', 'd'],
+			});
+		});
+	});
 
-  describe('transformNestedAsset', () => {
-    it('should transform result according to nested asset schema', () => {
-      const questions = prepareQuestions(transactions.VoteTransaction.ASSET_SCHEMA);
-      const transformedAsset = transformNestedAsset([{ votes: 'a,100' }, { votes: 'b,300' }], transactions.VoteTransaction.ASSET_SCHEMA);
+	describe('transformNestedAsset', () => {
+		it('should transform result according to nested asset schema', () => {
+			const questions = prepareQuestions(transactions.VoteTransaction.ASSET_SCHEMA);
+			const transformedAsset = transformNestedAsset(transactions.VoteTransaction.ASSET_SCHEMA, [
+				{ votes: 'a,100' },
+				{ votes: 'b,300' },
+			]);
 
-      expect(questions).to.deep.equal([
-        {
-          type: 'input',
-          name: 'votes',
-          message: 'Please enter: votes(delegateAddress, amount): '
-        },
-        {
-          type: 'confirm',
-          name: 'askAgain',
-          message: 'Want to enter another votes(delegateAddress, amount)'
-        }
-      ]);
-      expect(transformedAsset).to.deep.equal({
-        votes: [
-          { delegateAddress: 'a', amount: 100 },
-          { delegateAddress: 'b', amount: 300 },
-        ]
-      });
-    });
-  });
+			expect(questions).to.deep.equal([
+				{
+					type: 'input',
+					name: 'votes',
+					message: 'Please enter: votes(delegateAddress, amount): ',
+				},
+				{
+					type: 'confirm',
+					name: 'askAgain',
+					message: 'Want to enter another votes(delegateAddress, amount)',
+				},
+			]);
+			expect(transformedAsset).to.deep.equal({
+				votes: [
+					{ delegateAddress: 'a', amount: 100 },
+					{ delegateAddress: 'b', amount: 300 },
+				],
+			});
+		});
+	});
 });

--- a/test/commands/transaction/send.spec.ts
+++ b/test/commands/transaction/send.spec.ts
@@ -17,45 +17,10 @@ import { expect, test } from '@oclif/test';
 import * as sandbox from 'sinon';
 import * as fs from 'fs-extra';
 import { join } from 'path';
-import { IPCChannel } from 'lisk-sdk';
+import { IPCChannel, transactions } from 'lisk-sdk';
 
 import * as appUtils from '../../../src/utils/application';
 import { createTransferTransaction, encodeTransactionFromJSON } from '../../utils/transactions';
-
-const baseTransactionSchema = {
-	$id: 'lisk/base-transaction',
-	type: 'object',
-	required: ['type', 'nonce', 'fee', 'senderPublicKey', 'asset'],
-	properties: {
-		type: {
-			dataType: 'uint32',
-			fieldNumber: 1,
-		},
-		nonce: {
-			dataType: 'uint64',
-			fieldNumber: 2,
-		},
-		fee: {
-			dataType: 'uint64',
-			fieldNumber: 3,
-		},
-		senderPublicKey: {
-			dataType: 'bytes',
-			fieldNumber: 4,
-		},
-		asset: {
-			dataType: 'bytes',
-			fieldNumber: 5,
-		},
-		signatures: {
-			type: 'array',
-			items: {
-				dataType: 'bytes',
-			},
-			fieldNumber: 6,
-		},
-	},
-};
 
 const transferAssetSchema = {
 	$id: 'lisk/transfer-transaction',
@@ -95,7 +60,7 @@ describe('transaction:send command', () => {
 	});
 	const encodedTransaction = encodeTransactionFromJSON(
 		transferTransaction as any,
-		baseTransactionSchema,
+		transactions.BaseTransaction.BASE_SCHEMA,
 		transactionsAssets,
 	);
 	const fsStub = sandbox.stub().returns(true);
@@ -104,7 +69,7 @@ describe('transaction:send command', () => {
 	const pathToAppPIDFiles = join(__dirname, 'fake_test_app');
 	const ipcStartAndListenStub = sandbox.stub();
 	ipcInvokeStub.withArgs('app:getSchema').resolves({
-		baseTransaction: baseTransactionSchema,
+		baseTransaction: transactions.BaseTransaction.BASE_SCHEMA,
 		transactionsAssets,
 	});
 

--- a/test/utils/transactions.ts
+++ b/test/utils/transactions.ts
@@ -12,14 +12,9 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-import { transactions, codec } from 'lisk-sdk';
-import { config } from '../../src/config/devnet';
-
-interface Schema {
-	readonly $id: string;
-	readonly type: string;
-	readonly properties: Record<string, unknown>;
-}
+import { cryptography, transactions, codec } from 'lisk-sdk';
+import { genesisBlock } from '../../src/config/devnet';
+import { Schema } from '../../src/base_ipc';
 
 const account = {
 	passphrase: 'endless focus guilt bronze hold economy bulk parent soon tower cement venue',
@@ -28,6 +23,42 @@ const account = {
 	publicKey: 'UIqWWHElNZWzbi+Nwnv/bmezm91GZTG+nG+MQBJTl5w=',
 	address: 'nKvuPSdCZna4Us5rgEyy/f980LU=',
 };
+
+export const transferAssetSchema = {
+	$id: 'lisk/transfer-transaction',
+	title: 'Transfer transaction asset',
+	type: 'object',
+	required: ['amount', 'recipientAddress', 'data'],
+	properties: {
+		amount: {
+			dataType: 'uint64',
+			fieldNumber: 1,
+		},
+		recipientAddress: {
+			dataType: 'bytes',
+			fieldNumber: 2,
+			minLength: 20,
+			maxLength: 20,
+		},
+		data: {
+			dataType: 'string',
+			fieldNumber: 3,
+			minLength: 0,
+			maxLength: 64,
+		},
+	},
+};
+
+export const genesisBlockTransactionRoot = Buffer.from(
+	genesisBlock.header.transactionRoot,
+	'base64',
+);
+export const communityIdentifier = 'Lisk';
+
+export const networkIdentifier = cryptography.getNetworkIdentifier(
+	genesisBlockTransactionRoot,
+	communityIdentifier,
+);
 
 export const createTransferTransaction = ({
 	amount,
@@ -51,7 +82,7 @@ export const createTransferTransaction = ({
 		},
 	});
 
-	transaction.sign(Buffer.from(config.networkVersion), account.passphrase);
+	transaction.sign(networkIdentifier, account.passphrase);
 
 	return {
 		id: transaction.id.toString('base64'),

--- a/test/utils/transactions.ts
+++ b/test/utils/transactions.ts
@@ -24,31 +24,6 @@ const account = {
 	address: 'nKvuPSdCZna4Us5rgEyy/f980LU=',
 };
 
-export const transferAssetSchema = {
-	$id: 'lisk/transfer-transaction',
-	title: 'Transfer transaction asset',
-	type: 'object',
-	required: ['amount', 'recipientAddress', 'data'],
-	properties: {
-		amount: {
-			dataType: 'uint64',
-			fieldNumber: 1,
-		},
-		recipientAddress: {
-			dataType: 'bytes',
-			fieldNumber: 2,
-			minLength: 20,
-			maxLength: 20,
-		},
-		data: {
-			dataType: 'string',
-			fieldNumber: 3,
-			minLength: 0,
-			maxLength: 64,
-		},
-	},
-};
-
 export const genesisBlockTransactionRoot = Buffer.from(
 	genesisBlock.header.transactionRoot,
 	'base64',


### PR DESCRIPTION
### What was the problem?

This PR resolves #271 

### How was it solved?

- Introduced new `transaction:create` command
- Accepts args and flags to create transaction dynamically for a given asset

### How was it tested?

- Added unit test
- Run a devnet node `./bin/run start -n devnet --enable-http-api --enable-ipc`
- Create a transaction `./bin/run transaction:create hz2oWizucNpjHZCw8X+tqMOsm4OyYT9Mpf3dN00QNLM= 500000000 2 8 --asset='{"amount":100,"recipientAddress":"qwBBp9P3ssKQtbg01Gvce364WBU=","data":"send token"}' --passphrase="peanut hundred pen hawk invite exclude brain chunk gadget wait wrong ready" --pretty`