### PR TITLE
Implement Legacy account module - Closes #255

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
 	"dependencies": {
 		"@liskhq/lisk-db": "0.1.0-alpha.0",
 		"@liskhq/lisk-passphrase": "3.0.0",
+		"@liskhq/lisk-utils": "0.1.0-alpha.0",
 		"@oclif/command": "1.6.1",
 		"@oclif/config": "1.15.1",
 		"@oclif/plugin-help": "3.1.0",

--- a/src/application/modules/index.ts
+++ b/src/application/modules/index.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+export * from './legacy_account';

--- a/src/application/modules/legacy_account/constants.ts
+++ b/src/application/modules/legacy_account/constants.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+export const CHAIN_STATE_UNREGISTERED_ADDRESSES = 'unregisteredAddresses';

--- a/src/application/modules/legacy_account/index.ts
+++ b/src/application/modules/legacy_account/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+export * from './reclaim_asset';
+export * from './legacy_account_module';

--- a/src/application/modules/legacy_account/index.ts
+++ b/src/application/modules/legacy_account/index.ts
@@ -12,5 +12,5 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-export * from './reclaim_asset';
+export * from './transaction_assets/reclaim_asset';
 export * from './legacy_account_module';

--- a/src/application/modules/legacy_account/legacy_account_module.ts
+++ b/src/application/modules/legacy_account/legacy_account_module.ts
@@ -29,7 +29,7 @@ export class LegacyAccountModule extends BaseModule {
 		const { accounts } = genesisBlock.header.asset;
 		// New address is 20-byte value specified in LIP 0018 if the account has a registered public key.
 		// Otherwise, it is the 8-byte value of the legacy address.
-		const unregisteredAddresses = accounts.filter(a => a.address.length !== 20);
+		const unregisteredAddresses = accounts.filter(account => account.address.length !== 20);
 		const unregisteredAddressesWithBalance = await Promise.all(
 			unregisteredAddresses.map(async ({ address }) => {
 				const balance = await reducerHandler.invoke<bigint>('token:getBalance', { address });

--- a/src/application/modules/legacy_account/legacy_account_module.ts
+++ b/src/application/modules/legacy_account/legacy_account_module.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+import { AfterGenesisBlockApplyInput, BaseModule, codec } from 'lisk-sdk';
+import { CHAIN_STATE_UNREGISTERED_ADDRESSES } from './constants';
+import { unregisteredAddressesSchema } from './schema';
+
+export class LegacyAccountModule extends BaseModule {
+	public name = 'legacyAccount';
+	public type = 6;
+
+	// eslint-disable-next-line class-methods-use-this
+	public async afterGenesisBlockApply({
+		genesisBlock,
+		reducerHandler,
+		stateStore,
+	}: AfterGenesisBlockApplyInput): Promise<void> {
+		// Save unregistered addresses to state store
+		const { accounts } = genesisBlock.header.asset;
+		const unregisteredAddresses = accounts
+			.filter(a => a.address.length !== 20)
+			.map(({ address }) => ({ address }));
+		const unregisteredAddressesWithBalance = await Promise.all(
+			unregisteredAddresses.map(async ({ address }) => {
+				const balance = await reducerHandler.invoke<bigint>('token:getBalance', { address });
+				return { address, balance };
+			}),
+		);
+		const encodedUnregisteredAddresses = codec.encode(unregisteredAddressesSchema, {
+			unregisteredAddresses: unregisteredAddressesWithBalance,
+		});
+		stateStore.chain.set(CHAIN_STATE_UNREGISTERED_ADDRESSES, encodedUnregisteredAddresses);
+	}
+}

--- a/src/application/modules/legacy_account/reclaim_asset.ts
+++ b/src/application/modules/legacy_account/reclaim_asset.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+import { ApplyAssetInput, BaseAsset, codec, cryptography } from 'lisk-sdk';
+import { CHAIN_STATE_UNREGISTERED_ADDRESSES } from './constants';
+import { unregisteredAddressesSchema } from './schema';
+
+interface Asset {
+	readonly amount: bigint;
+}
+
+export interface UnregisteredAddresses {
+	readonly address: Buffer;
+	readonly amount: bigint;
+}
+
+export class ReclaimAsset extends BaseAsset<Asset> {
+	public name = 'reclaim';
+	public type = 0;
+	public assetSchema = {
+		$id: 'lisk/legacyAccount/reclaim',
+		title: 'Reclaim transaction asset',
+		type: 'object',
+		required: ['amount'],
+		properties: {
+			amount: {
+				dataType: 'uint64',
+				fieldNumber: 1,
+			},
+		},
+	};
+
+	// eslint-disable-next-line class-methods-use-this
+	public async applyAsset({
+		asset,
+		reducerHandler,
+		stateStore,
+		transaction: { senderPublicKey },
+	}: ApplyAssetInput<Asset>): Promise<void> {
+		const encodedUnregisteredAddresses = await stateStore.chain.get(
+			CHAIN_STATE_UNREGISTERED_ADDRESSES,
+		);
+
+		if (!encodedUnregisteredAddresses) {
+			throw new Error('Chain state does not contain any unregistered addresses');
+		}
+		const unregisteredAddresses = codec.decode<UnregisteredAddresses[]>(
+			unregisteredAddressesSchema,
+			encodedUnregisteredAddresses,
+		);
+		const legacyAddress = cryptography.getLegacyAddressFromPublicKey(senderPublicKey);
+		const addressWithoutPublickey = unregisteredAddresses.find(a =>
+			a.address.equals(Buffer.from(legacyAddress, 'base64')),
+		);
+
+		if (!addressWithoutPublickey) {
+			throw new Error(
+				'Legacy address corresponding to sender publickey was not found genesis account state',
+			);
+		}
+		if (asset.amount !== addressWithoutPublickey.amount) {
+			// eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+			throw new Error(`Invalid amount:${asset.amount} claimed by the sender: ${senderPublicKey}`);
+		}
+		const newAddress = cryptography.getAddressFromPublicKey(senderPublicKey);
+		const reclaimAccount = await stateStore.account.getOrDefault(newAddress);
+		await reducerHandler.invoke(
+			'token:credit',
+			(reclaimAccount as unknown) as Record<string, unknown>,
+		);
+	}
+}

--- a/src/application/modules/legacy_account/schema.ts
+++ b/src/application/modules/legacy_account/schema.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+export const unregisteredAddressesSchema = {
+	$id: '/legacyAccount/unregisteredAddresses',
+	type: 'object',
+	properties: {
+		unregisteredAddresses: {
+			type: 'array',
+			fieldNumber: 1,
+			items: {
+				type: 'object',
+				properties: {
+					address: {
+						dataType: 'bytes',
+						fieldNumber: 1,
+					},
+					amount: {
+						dataType: 'uint64',
+						fieldNumber: 2,
+					},
+				},
+				required: ['address', 'amount'],
+			},
+		},
+	},
+	required: ['unregisteredAddresses'],
+};

--- a/src/application/modules/legacy_account/schema.ts
+++ b/src/application/modules/legacy_account/schema.ts
@@ -26,14 +26,27 @@ export const unregisteredAddressesSchema = {
 						dataType: 'bytes',
 						fieldNumber: 1,
 					},
-					amount: {
+					balance: {
 						dataType: 'uint64',
 						fieldNumber: 2,
 					},
 				},
-				required: ['address', 'amount'],
+				required: ['address', 'balance'],
 			},
 		},
 	},
 	required: ['unregisteredAddresses'],
+};
+
+export const reclaimAssetSchema = {
+	$id: 'lisk/legacyAccount/reclaim',
+	title: 'Reclaim transaction asset',
+	type: 'object',
+	required: ['amount'],
+	properties: {
+		amount: {
+			dataType: 'uint64',
+			fieldNumber: 1,
+		},
+	},
 };

--- a/test/application/modules/legacy_account/legacy_account_module.spec.ts
+++ b/test/application/modules/legacy_account/legacy_account_module.spec.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+
+import { expect } from 'chai';
+import * as sandbox from 'sinon';
+import { AfterGenesisBlockApplyInput, cryptography, GenesisConfig, codec } from 'lisk-sdk';
+import { testing } from '@liskhq/lisk-utils';
+import { LegacyAccountModule } from '../../../../src/application/modules';
+import { createAccount, createFakeDefaultAccount } from '../../../utils/account';
+import { unregisteredAddressesSchema } from '../../../../src/application/modules/legacy_account/schema';
+import { CHAIN_STATE_UNREGISTERED_ADDRESSES } from '../../../../src/application/modules/legacy_account/constants';
+
+describe('LegacyAccountModule', () => {
+	let defaultAccount;
+	let legacyAccountModule: LegacyAccountModule;
+	let afterGenesisBlockApplyInput: AfterGenesisBlockApplyInput;
+	let sender;
+	const legacyBalance = BigInt(100000000000);
+	const reducerHandlerStub = {
+		invoke: sandbox.stub().resolves(legacyBalance),
+	};
+	const getLegacyAddressBuffer = (publicKey: Buffer) =>
+		Buffer.from(cryptography.getLegacyAddressFromPublicKey(publicKey), 'base64');
+
+	beforeEach(() => {
+		defaultAccount = createAccount();
+		sender = createFakeDefaultAccount(defaultAccount);
+		// assign legacy address
+		sender.address = getLegacyAddressBuffer(defaultAccount.publicKey);
+
+		const genesisBlock = {
+			header: {
+				asset: {
+					accounts: [sender],
+				},
+			},
+		};
+
+		legacyAccountModule = new LegacyAccountModule({} as GenesisConfig);
+
+		afterGenesisBlockApplyInput = {
+			genesisBlock,
+			reducerHandler: reducerHandlerStub,
+			stateStore: new testing.StateStoreMock({ accounts: [sender] }),
+		} as any;
+	});
+
+	afterEach(() => {
+		reducerHandlerStub.invoke.resetHistory();
+	});
+
+	describe('constructor', () => {
+		it('should have valid type', () => {
+			expect(legacyAccountModule.type).to.equal(6);
+		});
+
+		it('should have valid name', () => {
+			expect(legacyAccountModule.name).to.equal('legacyAccount');
+		});
+	});
+
+	describe('afterGenesisBlockApply', () => {
+		it('should invoke token:getBalance for each account', async () => {
+			await legacyAccountModule.afterGenesisBlockApply(afterGenesisBlockApplyInput);
+
+			const oldAddress = getLegacyAddressBuffer(defaultAccount.publicKey);
+			expect(reducerHandlerStub.invoke).to.be.calledOnce;
+			expect(reducerHandlerStub.invoke).to.be.calledOnceWithExactly('token:getBalance', {
+				address: oldAddress,
+			});
+		});
+
+		it('should save unregistered accounts to state store', async () => {
+			await legacyAccountModule.afterGenesisBlockApply(afterGenesisBlockApplyInput);
+
+			const encodedUnregisteredAddresses = codec.encode(unregisteredAddressesSchema, {
+				unregisteredAddresses: [
+					{
+						address: getLegacyAddressBuffer(defaultAccount.publicKey),
+						balance: legacyBalance,
+					},
+				],
+			});
+
+			const savedResult = await afterGenesisBlockApplyInput.stateStore.chain.get(
+				CHAIN_STATE_UNREGISTERED_ADDRESSES,
+			);
+			expect(encodedUnregisteredAddresses.equals(savedResult as Buffer)).to.be.true;
+		});
+	});
+});

--- a/test/application/modules/legacy_account/reclaim_asset.spec.ts
+++ b/test/application/modules/legacy_account/reclaim_asset.spec.ts
@@ -1,0 +1,147 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+
+import { expect } from 'chai';
+import * as sandbox from 'sinon';
+import { ApplyAssetInput, cryptography, codec } from 'lisk-sdk';
+import { testing } from '@liskhq/lisk-utils';
+import { ReclaimAsset } from '../../../../src/application/modules';
+import {
+	reclaimAssetSchema,
+	unregisteredAddressesSchema,
+} from '../../../../src/application/modules/legacy_account/schema';
+import { CHAIN_STATE_UNREGISTERED_ADDRESSES } from '../../../../src/application/modules/legacy_account/constants';
+import { createAccount, createFakeDefaultAccount } from '../../../utils/account';
+
+describe('ReclaimAsset', () => {
+	let defaultAccount;
+	let reclaimAsset: ReclaimAsset;
+	let reclaimAssetInput: ApplyAssetInput<{
+		readonly amount: bigint;
+	}>;
+	let sender;
+	const chainMockData = {};
+	const reducerHandlerStub = {
+		invoke: sandbox.stub().resolves(),
+	};
+	const randomPublicKey = Buffer.from(
+		'0fe9a3f1a21b5530f27f87a414b549e79a940bf24fdf2b2f05e7f22aeeecc86a',
+		'hex',
+	);
+	const encodeUnregisteredAddresses = unregisteredAddresses => {
+		return codec.encode(unregisteredAddressesSchema, {
+			unregisteredAddresses,
+		});
+	};
+	const balanceToClaim = BigInt(100000000000);
+	const getAddressBuffer = (publicKey: Buffer) =>
+		Buffer.from(cryptography.getLegacyAddressFromPublicKey(publicKey), 'base64');
+
+	beforeEach(() => {
+		defaultAccount = createAccount();
+		sender = createFakeDefaultAccount(defaultAccount);
+		reclaimAsset = new ReclaimAsset();
+
+		const unregisteredAddresses = [
+			{ address: getAddressBuffer(defaultAccount.publicKey), balance: balanceToClaim },
+		];
+
+		chainMockData[CHAIN_STATE_UNREGISTERED_ADDRESSES] = encodeUnregisteredAddresses(
+			unregisteredAddresses,
+		);
+		reclaimAssetInput = {
+			asset: {
+				amount: balanceToClaim,
+			},
+			reducerHandler: reducerHandlerStub,
+			stateStore: new testing.StateStoreMock({ accounts: [sender], chain: chainMockData }),
+			transaction: { senderPublicKey: defaultAccount.publicKey },
+		} as any;
+	});
+
+	afterEach(() => {
+		reducerHandlerStub.invoke.resetHistory();
+	});
+
+	describe('constructor', () => {
+		it('should have valid type', () => {
+			expect(reclaimAsset.type).to.equal(0);
+		});
+
+		it('should have valid name', () => {
+			expect(reclaimAsset.name).to.equal('reclaim');
+		});
+
+		it('should have valid assetSchema', () => {
+			expect(reclaimAsset.assetSchema).to.deep.equal(reclaimAssetSchema);
+		});
+	});
+
+	describe('applyAsset', () => {
+		it('should throw error when chain state store does not have unregistered addresses', () => {
+			reclaimAssetInput.stateStore = new testing.StateStoreMock({
+				accounts: [sender],
+				chain: {},
+			}) as any;
+			expect(reclaimAsset.applyAsset(reclaimAssetInput)).to.rejectedWith(
+				'Chain state does not contain any unregistered addresses',
+			);
+		});
+
+		it('should throw error when reclaim senderPublickey corresponding address is not found in unregistered address', () => {
+			const unregisteredAddresses = [
+				{ address: getAddressBuffer(randomPublicKey), balance: balanceToClaim },
+			];
+			chainMockData[CHAIN_STATE_UNREGISTERED_ADDRESSES] = encodeUnregisteredAddresses(
+				unregisteredAddresses,
+			);
+
+			reclaimAssetInput.stateStore = new testing.StateStoreMock({
+				accounts: [sender],
+				chain: chainMockData,
+			}) as any;
+			expect(reclaimAsset.applyAsset(reclaimAssetInput)).to.rejectedWith(
+				'Legacy address corresponding to sender publickey was not found genesis account state',
+			);
+		});
+
+		it('should throw error when reclaim amount does not match unregistered address amount', () => {
+			const unregisteredAddresses = [
+				{ address: getAddressBuffer(defaultAccount.publicKey), amount: BigInt(500000000000) },
+			];
+			chainMockData[CHAIN_STATE_UNREGISTERED_ADDRESSES] = encodeUnregisteredAddresses(
+				unregisteredAddresses,
+			);
+
+			reclaimAssetInput.stateStore = new testing.StateStoreMock({
+				accounts: [sender],
+				chain: chainMockData,
+			}) as any;
+			expect(reclaimAsset.applyAsset(reclaimAssetInput)).to.rejectedWith(
+				'Invalid amount:100000000000 claimed by the sender',
+			);
+		});
+
+		it('should credit amount from unregistered address to new address', async () => {
+			await reclaimAsset.applyAsset(reclaimAssetInput);
+			const newAddress = cryptography.getAddressFromPublicKey(defaultAccount.publicKey);
+			expect(reducerHandlerStub.invoke).to.be.calledOnce;
+			expect(reducerHandlerStub.invoke).to.be.calledOnceWithExactly('token:credit', {
+				address: newAddress,
+				amount: balanceToClaim,
+			});
+		});
+	});
+});

--- a/test/utils/account.ts
+++ b/test/utils/account.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2018 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+
+import { Mnemonic } from '@liskhq/lisk-passphrase';
+import { cryptography } from 'lisk-sdk';
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export const createAccount = () => {
+	const passphrase = Mnemonic.generateMnemonic();
+	const { privateKey, publicKey } = cryptography.getKeys(passphrase);
+	const address = cryptography.getAddressFromPublicKey(publicKey);
+
+	return {
+		passphrase,
+		privateKey,
+		publicKey,
+		address,
+	};
+};
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export const createAccounts = (numberOfAccounts = 1) => {
+	const accounts = new Array(numberOfAccounts).fill(0).map(createAccount);
+	return accounts;
+};
+
+export const createFakeDefaultAccount = (account: any) => ({
+	address: account?.address ?? cryptography.getRandomBytes(20),
+	token: {
+		balance: account?.token?.balance ?? BigInt(0),
+	},
+	sequence: {
+		nonce: account?.sequence?.nonce ?? BigInt(0),
+	},
+	keys: {
+		mandatoryKeys: account?.keys?.mandatoryKeys ?? [],
+		optionalKeys: account?.keys?.optionalKeys ?? [],
+		numberOfSignatures: account?.keys?.numberOfSignatures ?? 0,
+	},
+	dpos: {
+		delegate: {
+			username: account?.dpos?.delegate?.username ?? '',
+			pomHeights: account?.dpos?.delegate?.pomHeights ?? [],
+			consecutiveMissedBlocks: account?.dpos?.delegate?.consecutiveMissedBlocks ?? 0,
+			lastForgedHeight: account?.dpos?.delegate?.lastForgedHeight ?? 0,
+			isBanned: account?.dpos?.delegate?.isBanned ?? false,
+			totalVotesReceived: account?.dpos?.delegate?.totalVotesReceived ?? BigInt(0),
+		},
+		sentVotes: account?.dpos?.sentVotes ?? [],
+		unlocking: account?.dpos?.unlocking ?? [],
+	},
+});


### PR DESCRIPTION
### What was the problem?

This PR resolves #255 

### How was it solved?

- Legacy account allows users to reclaim the account which do not have publickey association
- We check if oldAddress(sender.publicKey) is in legacy accounts
- We check if reclaim amount matches legacy balance
- If all succedd we credit account with balance
- And remove entry from legacy accounts

### How was it tested?

- Added unit tests