### PR TITLE
Update legacy account module to remove legacy account - Closes #324

### DIFF
--- a/src/application/index.ts
+++ b/src/application/index.ts
@@ -12,6 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 import { Application, ApplicationConfig, HTTPAPIPlugin, ForgerPlugin } from 'lisk-sdk';
+import { LegacyAccountModule } from './modules';
 
 export interface Options {
 	enableHTTPAPI: boolean;
@@ -26,6 +27,7 @@ export const getApplication = (
 	options: Options,
 ): Application => {
 	const app = Application.defaultApplication(genesisBlock, config);
+	app.registerModule(LegacyAccountModule);
 
 	if (options.enableHTTPAPI) {
 		app.registerPlugin(HTTPAPIPlugin);

--- a/src/application/modules/legacy_account/legacy_account_module.ts
+++ b/src/application/modules/legacy_account/legacy_account_module.ts
@@ -39,7 +39,10 @@ export class LegacyAccountModule extends BaseModule {
 		const encodedUnregisteredAddresses = codec.encode(unregisteredAddressesSchema, {
 			unregisteredAddresses: unregisteredAddressesWithBalance,
 		});
-
+		// Delete legacy account from account state
+		for (const { address } of unregisteredAddresses) {
+			await stateStore.account.del(address);
+		}
 		stateStore.chain.set(CHAIN_STATE_UNREGISTERED_ADDRESSES, encodedUnregisteredAddresses);
 	}
 }

--- a/src/application/modules/legacy_account/legacy_account_module.ts
+++ b/src/application/modules/legacy_account/legacy_account_module.ts
@@ -15,10 +15,12 @@
 import { AfterGenesisBlockApplyInput, BaseModule, codec } from 'lisk-sdk';
 import { CHAIN_STATE_UNREGISTERED_ADDRESSES } from './constants';
 import { unregisteredAddressesSchema } from './schema';
+import { ReclaimAsset } from './transaction_assets/reclaim_asset';
 
 export class LegacyAccountModule extends BaseModule {
 	public name = 'legacyAccount';
 	public type = 6;
+	public transactionAssets = [new ReclaimAsset()];
 
 	// eslint-disable-next-line class-methods-use-this
 	public async afterGenesisBlockApply({

--- a/test/application/modules/legacy_account/legacy_account_module.spec.ts
+++ b/test/application/modules/legacy_account/legacy_account_module.spec.ts
@@ -62,7 +62,7 @@ describe('LegacyAccountModule', () => {
 		afterGenesisBlockApplyInput = {
 			genesisBlock,
 			reducerHandler: reducerHandlerStub,
-			stateStore: new testing.StateStoreMock({ accounts: [legacyAccount1, legacyAccount2] }),
+			stateStore: new testing.StateStoreMock({ accounts: [legacyAccount1, legacyAccount2, newAccount] }),
 		} as any;
 	});
 
@@ -115,6 +115,12 @@ describe('LegacyAccountModule', () => {
 				CHAIN_STATE_UNREGISTERED_ADDRESSES,
 			);
 			expect(encodedUnregisteredAddresses).to.deep.equal(savedResult);
+		});
+
+		it('should delete unregistered accounts from state store', async () => {
+			await legacyAccountModule.afterGenesisBlockApply(afterGenesisBlockApplyInput);
+			const updatedAccounts = afterGenesisBlockApplyInput.stateStore.account.getUpdated();
+			expect(updatedAccounts).to.have.lengthOf(1);
 		});
 	});
 });

--- a/test/application/modules/legacy_account/legacy_account_module.spec.ts
+++ b/test/application/modules/legacy_account/legacy_account_module.spec.ts
@@ -62,7 +62,9 @@ describe('LegacyAccountModule', () => {
 		afterGenesisBlockApplyInput = {
 			genesisBlock,
 			reducerHandler: reducerHandlerStub,
-			stateStore: new testing.StateStoreMock({ accounts: [legacyAccount1, legacyAccount2, newAccount] }),
+			stateStore: new testing.StateStoreMock({
+				accounts: [legacyAccount1, legacyAccount2, newAccount],
+			}),
 		} as any;
 	});
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #324 

### How was it solved?
Remove legacy account from the account state


### How was it tested?
Added unit test 