### PR TITLE
Fix import path - Closes #335

### DIFF
--- a/src/commands/transaction/create.ts
+++ b/src/commands/transaction/create.ts
@@ -19,7 +19,6 @@ import { codec, cryptography, transactions, validator } from 'lisk-sdk';
 import BaseIPCCommand from '../../base_ipc';
 import { flags as commonFlags } from '../../utils/flags';
 import { getAssetFromPrompt, getPassphraseFromPrompt } from '../../utils/reader';
-import { LiskValidationError } from '../../../../lisk-sdk/node_modules/@liskhq/lisk-validator/dist-node';
 
 interface Args {
 	readonly nonce: string;
@@ -117,7 +116,7 @@ export default class CreateCommand extends BaseIPCCommand {
 		const assetObject = codec.fromJSON(assetSchema.schema, rawAsset);
 		const assetErrors = validator.validator.validate(assetSchema.schema, assetObject);
 		if (assetErrors.length) {
-			throw new LiskValidationError([...assetErrors]);
+			throw new validator.LiskValidationError([...assetErrors]);
 		}
 
 		if (!senderPublicKeySource && noSignature) {
@@ -150,7 +149,7 @@ export default class CreateCommand extends BaseIPCCommand {
 			transactionObject,
 		);
 		if (transactionErrors.length) {
-			throw new LiskValidationError([...transactionErrors]);
+			throw new validator.LiskValidationError([...transactionErrors]);
 		}
 
 		transactionObject.asset = assetObject;


### PR DESCRIPTION
### What was the problem?

This PR resolves #335 

### How was it solved?

- Fix import path not to use relative SDK path

### How was it tested?
Run ` ./bin/run transaction:create hz2oWizucNpjHZCw8X+tqMOsm4OyYT9Mpf3dN00QNLM= 100000000 2 2 0`

