### PR TITLE
Fix not ensuring the dir before checking - Closes #355

### DIFF
--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -60,6 +60,7 @@ export const getDefaultNetworkConfigFilesPath = (
 
 export const getConfigDirs = (dataPath: string): string[] => {
 	const configPath = getConfigPath(dataPath);
+	fs.ensureDirSync(configPath);
 	const files = fs.readdirSync(configPath);
 	return files.filter(file => fs.statSync(path.join(configPath, file)).isDirectory());
 };

--- a/test/application/modules/legacy_account/legacy_account_module.spec.ts
+++ b/test/application/modules/legacy_account/legacy_account_module.spec.ts
@@ -120,8 +120,8 @@ describe('LegacyAccountModule', () => {
 
 		it('should delete unregistered accounts from state store', async () => {
 			await legacyAccountModule.afterGenesisBlockApply(afterGenesisBlockApplyInput);
-			const updatedAccounts = afterGenesisBlockApplyInput.stateStore.account.getUpdated();
-			expect(updatedAccounts).to.have.lengthOf(1);
+			await expect(afterGenesisBlockApplyInput.stateStore.account.get(legacyAccount1.address)).to.be.rejectedWith('Account not defined');
+			await expect(afterGenesisBlockApplyInput.stateStore.account.get(legacyAccount2.address)).to.be.rejectedWith('Account not defined');
 		});
 	});
 });

--- a/test/application/modules/legacy_account/legacy_account_module.spec.ts
+++ b/test/application/modules/legacy_account/legacy_account_module.spec.ts
@@ -120,8 +120,12 @@ describe('LegacyAccountModule', () => {
 
 		it('should delete unregistered accounts from state store', async () => {
 			await legacyAccountModule.afterGenesisBlockApply(afterGenesisBlockApplyInput);
-			await expect(afterGenesisBlockApplyInput.stateStore.account.get(legacyAccount1.address)).to.be.rejectedWith('Account not defined');
-			await expect(afterGenesisBlockApplyInput.stateStore.account.get(legacyAccount2.address)).to.be.rejectedWith('Account not defined');
+			await expect(
+				afterGenesisBlockApplyInput.stateStore.account.get(legacyAccount1.address),
+			).to.be.rejectedWith('Account not defined');
+			await expect(
+				afterGenesisBlockApplyInput.stateStore.account.get(legacyAccount2.address),
+			).to.be.rejectedWith('Account not defined');
 		});
 	});
 });

--- a/test/commands/start.spec.ts
+++ b/test/commands/start.spec.ts
@@ -94,6 +94,7 @@ describe('start', () => {
 		setupTest()
 			.command(['start', '-n', 'devnet', '--overwrite-config'])
 			.it('should delete the mainnet config and save the devnet config', () => {
+				expect(fs.ensureDirSync).to.have.been.calledWith('~/.lisk/default/config');
 				expect(fs.removeSync).to.have.been.calledOnce;
 				expect(fs.copyFileSync).to.have.been.calledTwice;
 			});


### PR DESCRIPTION
### What was the problem?

This PR resolves #355 

### How was it solved?

- Ensure folder before the validation

### How was it tested?

- ./bin/start start -n devnet -d ./new-folder
- ./bin/start start -n devnet
