### PR TITLE
Transaction create command fails for prompt asset type object - Closes #357

### DIFF
--- a/src/commands/transaction/create.ts
+++ b/src/commands/transaction/create.ts
@@ -110,10 +110,12 @@ export default class CreateCommand extends BaseIPCCommand {
 				`Transaction moduleID:${moduleID} with assetID:${assetID} is not registered in the application`,
 			);
 		}
+
 		const rawAsset = assetSource
 			? JSON.parse(assetSource)
 			: await getAssetFromPrompt(assetSchema.schema);
 		const assetObject = codec.fromJSON(assetSchema.schema, rawAsset);
+
 		const assetErrors = validator.validator.validate(assetSchema.schema, assetObject);
 		if (assetErrors.length) {
 			throw new validator.LiskValidationError([...assetErrors]);


### PR DESCRIPTION
### What was the problem?

This PR resolves #357

### How was it solved?

Parse input value of type object

### How was it tested?

- Run a devnet node locally
- Run command
```
./bin/run transaction:create $NETWORK_IDENTIFIER $FEE $NONCE 5 3
```
```
header1:
{"version":2,"timestamp":1599080586,"height":1,"previousBlockID":"017192d8da7d20b419b2129ea51f5e9358fb0ea4904366a4ca6f887587bfbda0","transactionRoot":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","generatorPublicKey":"4b4fe5548c7a660ac6bb78262c5ec51f21d825ef81456aed2e87f0e3ff6c7af3","reward":"0","asset":{"maxHeightPreviouslyForged":0,"maxHeightPrevoted":0,"seedReveal":"963e97e77e42850891ec0bd1ab0e439c"}}

header2:
{"version":2,"timestamp":1599080586,"height":2,"previousBlockID":"017192d8da7d20b419b2129ea51f5e9358fb0ea4904366a4ca6f887587bfbda0","transactionRoot":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","generatorPublicKey":"4b4fe5548c7a660ac6bb78262c5ec51f21d825ef81456aed2e87f0e3ff6c7af3","reward":"0","asset":{"maxHeightPreviouslyForged":0,"maxHeightPrevoted":0,"seedReveal":"963e97e77e42850891ec0bd1ab0e439c"}}
```
- Enter input block headers
