### PR TITLE
Blockchain download command outputs file in incorrect path - Closes #359

### DIFF
--- a/src/commands/blockchain/download.ts
+++ b/src/commands/blockchain/download.ts
@@ -38,8 +38,8 @@ export default class DownloadCommand extends Command {
 		output: flagParser.string({
 			char: 'o',
 			description:
-				'Directory path to specify where snapshot is downloaded. Environment variable "LISK_DATA_PATH" can also be used.',
-			env: 'LISK_DATA_PATH',
+				'Directory path to specify where snapshot is downloaded. By default outputs the files to current working directory.',
+			default: '.',
 		}),
 		url: flagParser.string({
 			char: 'u',

--- a/src/commands/blockchain/download.ts
+++ b/src/commands/blockchain/download.ts
@@ -39,7 +39,7 @@ export default class DownloadCommand extends Command {
 			char: 'o',
 			description:
 				'Directory path to specify where snapshot is downloaded. By default outputs the files to current working directory.',
-			default: '.',
+			default: process.cwd(),
 		}),
 		url: flagParser.string({
 			char: 'u',

--- a/src/utils/download.ts
+++ b/src/utils/download.ts
@@ -27,12 +27,11 @@ export interface FileInfo {
 export const getDownloadedFileInfo = (url: string, downloadDir: string): FileInfo => {
 	const pathWithoutProtocol = url.replace(/(^\w+:|^)\/\//, '').split('/');
 	const fileName = pathWithoutProtocol.pop() as string;
-	const fileDir = `${downloadDir}/${pathWithoutProtocol.join('/')}`;
-	const filePath = `${fileDir}/${fileName}`;
+	const filePath = `${downloadDir}/${fileName}`;
 
 	return {
 		fileName,
-		fileDir,
+		fileDir: downloadDir,
 		filePath,
 	};
 };

--- a/src/utils/download.ts
+++ b/src/utils/download.ts
@@ -17,6 +17,7 @@ import * as crypto from 'crypto';
 import * as axios from 'axios';
 import * as fs from 'fs-extra';
 import * as tar from 'tar';
+import * as path from 'path';
 
 export interface FileInfo {
 	readonly fileName: string;
@@ -27,7 +28,7 @@ export interface FileInfo {
 export const getDownloadedFileInfo = (url: string, downloadDir: string): FileInfo => {
 	const pathWithoutProtocol = url.replace(/(^\w+:|^)\/\//, '').split('/');
 	const fileName = pathWithoutProtocol.pop() as string;
-	const filePath = `${downloadDir}/${fileName}`;
+	const filePath = path.join(downloadDir, fileName);
 
 	return {
 		fileName,

--- a/test/commands/blockchain/download.spec.ts
+++ b/test/commands/blockchain/download.spec.ts
@@ -18,12 +18,11 @@ import * as sandbox from 'sinon';
 import { Application } from 'lisk-sdk';
 import * as application from '../../../src/application';
 import * as downloadUtils from '../../../src/utils/download';
-import { getDefaultPath } from '../../../src/utils/path';
 
 const SNAPSHOT_URL = 'https://downloads.lisk.io/lisk/mainnet/blockchain.db.gz';
 
 describe('blockchain:download', () => {
-	const dataPath = getDefaultPath();
+	const dataPath = process.cwd();
 	const downloadAndValidateStub = sandbox.stub().resolves(undefined);
 
 	const setupTest = () =>


### PR DESCRIPTION
### What was the problem?

This PR resolves #INSERT_ISSUE_NUMBER

### How was it solved?

- By default download to CWD
- Download file to specified path

### How was it tested?

- For default path `./bin/run blockchain:download -u https://downloads.lisk.io/lisk/beta/blockchain.db.gz -n devnet`
- For output path `./bin/run blockchain:download -u https://downloads.lisk.io/lisk/beta/blockchain.db.gz -n devnet -o /tmp`