### PR TITLE
Add address create,show and validate commands - Closes #337 and #341

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,9 @@
 	"bin": {
 		"lisk-core": "./bin/run"
 	},
+	"lisk": {
+		"addressPrefix": "lsk"
+	},
 	"oclif": {
 		"bin": "lisk-core",
 		"commands": "./dist/commands",

--- a/src/commands/account/create.ts
+++ b/src/commands/account/create.ts
@@ -1,0 +1,76 @@
+/*
+ * LiskHQ/lisk-commander
+ * Copyright © 2019 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import { Command, flags as flagParser } from '@oclif/command';
+
+import { passphrase, cryptography } from 'lisk-sdk';
+
+interface AccountInfo {
+	readonly address: string;
+	readonly binaryAddress: string;
+	readonly passphrase: string;
+	readonly privateKey: string;
+	readonly publicKey: string;
+}
+
+const createAccount = (prefix: string): AccountInfo => {
+	const generatedPassphrase = passphrase.Mnemonic.generateMnemonic();
+	const { privateKey, publicKey } = cryptography.getKeys(generatedPassphrase);
+	const binaryAddress = cryptography.getAddressFromPublicKey(publicKey);
+	const address = cryptography.getBase32AddressFromPublicKey(publicKey, prefix);
+
+	return {
+		passphrase: generatedPassphrase,
+		privateKey: privateKey.toString('hex'),
+		publicKey: publicKey.toString('hex'),
+		binaryAddress: binaryAddress.toString('hex'),
+		address,
+	};
+};
+
+export default class CreateCommand extends Command {
+	static description = `
+		Returns a randomly-generated mnemonic passphrase with its corresponding public/private key pair and Lisk address.
+	`;
+
+	static examples = ['account:create', 'account:create --number=3'];
+
+	static flags = {
+		number: flagParser.string({
+			char: 'n',
+			description: 'Number of accounts to create.',
+			default: '1',
+		}),
+	};
+
+	// eslint-disable-next-line @typescript-eslint/require-await
+	async run(): Promise<void> {
+		const {
+			flags: { number: numberStr },
+		} = this.parse(CreateCommand);
+		const numberOfAccounts = parseInt(numberStr, 10);
+		if (
+			numberStr !== numberOfAccounts.toString() ||
+			!Number.isInteger(numberOfAccounts) ||
+			numberOfAccounts <= 0
+		) {
+			throw new Error('Number flag must be an integer and greater than 0');
+		}
+		const accounts = new Array(numberOfAccounts)
+			.fill(0)
+			.map(() => createAccount(this.config.pjson.lisk.addressPrefix));
+		this.log(JSON.stringify(accounts, undefined, ' '));
+	}
+}

--- a/src/commands/account/show.ts
+++ b/src/commands/account/show.ts
@@ -1,0 +1,68 @@
+/*
+ * LiskHQ/lisk-commander
+ * Copyright © 2019 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import { Command, flags as flagParser } from '@oclif/command';
+import { cryptography } from 'lisk-sdk';
+
+import { flags as commonFlags } from '../../utils/flags';
+import { getPassphraseFromPrompt } from '../../utils/reader';
+
+const processInput = (
+	passphrase: string,
+	prefix: string,
+): {
+	privateKey: string;
+	publicKey: string;
+	address: string;
+	binaryAddress: string;
+} => {
+	const { privateKey, publicKey } = cryptography.getKeys(passphrase);
+	const binaryAddress = cryptography.getAddressFromPublicKey(publicKey);
+	const address = cryptography.getBase32AddressFromPublicKey(publicKey, prefix);
+
+	return {
+		privateKey: privateKey.toString('hex'),
+		publicKey: publicKey.toString('hex'),
+		address,
+		binaryAddress: binaryAddress.toString('hex'),
+	};
+};
+
+export default class ShowCommand extends Command {
+	static description = `
+		Shows account information for a given passphrase.
+	`;
+
+	static examples = ['account:show'];
+
+	static flags = {
+		passphrase: flagParser.string(commonFlags.passphrase),
+	};
+
+	async run(): Promise<void> {
+		const {
+			flags: { passphrase: passphraseSource },
+		} = this.parse(ShowCommand);
+		const passphrase = passphraseSource ?? (await getPassphraseFromPrompt('passphrase', true));
+
+		this.log(
+			JSON.stringify(
+				processInput(passphrase, this.config.pjson.lisk.addressPrefix),
+				undefined,
+				' ',
+			),
+		);
+	}
+}

--- a/src/commands/account/validate.ts
+++ b/src/commands/account/validate.ts
@@ -1,0 +1,53 @@
+/*
+ * LiskHQ/lisk-commander
+ * Copyright © 2019 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import { Command, flags as flagParser } from '@oclif/command';
+import { cryptography } from 'lisk-sdk';
+
+import { flags as commonFlags } from '../../utils/flags';
+
+export default class ValidateCommand extends Command {
+	static description = `
+		Validates base32 address.
+	`;
+
+	static examples = ['account:validate'];
+
+	static args = [
+		{
+			name: 'address',
+			required: true,
+			description: 'Address in base32 format to validate.',
+		},
+	];
+
+	static flags = {
+		passphrase: flagParser.string(commonFlags.passphrase),
+	};
+
+	// eslint-disable-next-line @typescript-eslint/require-await
+	async run(): Promise<void> {
+		const {
+			args: { address },
+		} = this.parse(ValidateCommand);
+		try {
+			cryptography.validateBase32Address(address, this.config.pjson.lisk.addressPrefix);
+			// eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+			this.log(`Address ${address} is a valid address`);
+		} catch (error) {
+			this.error(error.message);
+		}
+	}
+}

--- a/test/commands/account/create.spec.ts
+++ b/test/commands/account/create.spec.ts
@@ -1,0 +1,140 @@
+/*
+ * LiskHQ/lisk-commander
+ * Copyright © 2019 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import * as sandbox from 'sinon';
+import { expect, test } from '@oclif/test';
+import { cryptography, passphrase } from 'lisk-sdk';
+
+describe('account:create', () => {
+	const defaultMnemonic =
+		'lab mirror fetch tuna village sell sphere truly excite manual planet capable';
+	const secondDefaultMnemonic =
+		'alone cabin buffalo blast region upper jealous basket brush put answer twice';
+	const defaultKeys = {
+		publicKey: '88b182d9f2d8a7c3b481a8962ae7d445b7a118fbb6a6f3afcedf4e0e8c46ecac',
+		privateKey:
+			'1a8ea0ceed1b85c9cff5eb12ae8d9ccdac93b5d5c668775e12b86dd63a8cefa688b182d9f2d8a7c3b481a8962ae7d445b7a118fbb6a6f3afcedf4e0e8c46ecac',
+	};
+	const secondDefaultKeys = {
+		publicKey: '90215077294ac1c727b357978df9291b77a8a700e6e42545dc0e6e5ba9582f13',
+		privateKey:
+			'bec5ac9d074d1684f9dd184fc44c4b37fb73ca9d013b6ddf5a92578a98f8848990215077294ac1c727b357978df9291b77a8a700e6e42545dc0e6e5ba9582f13',
+	};
+	const defaultAddress = 'lskz928ku6wx7ao89y9c4c24cqdduasdvquzvqksj';
+	const secondDefaultAddress = 'lskc3xa98z2pfa4c67anmanuporca2t3tdd6523kk';
+
+	// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+	const setupTest = () => {
+		const getKeysStub = sandbox.stub();
+		getKeysStub.withArgs(defaultMnemonic).returns(defaultKeys);
+		getKeysStub.withArgs(secondDefaultMnemonic).returns(secondDefaultKeys);
+
+		const getAddressFromPublicKeyStub = sandbox.stub();
+		getAddressFromPublicKeyStub.withArgs(defaultKeys.publicKey).returns(defaultAddress);
+		getAddressFromPublicKeyStub.withArgs(secondDefaultKeys.publicKey).returns(secondDefaultAddress);
+
+		return test
+			.stub(
+				passphrase.Mnemonic,
+				'generateMnemonic',
+				sandbox
+					.stub()
+					.onFirstCall()
+					.returns(defaultMnemonic)
+					.onSecondCall()
+					.returns(secondDefaultMnemonic),
+			)
+			.stdout();
+	};
+
+	describe('account:create', () => {
+		setupTest()
+			.command(['account:create'])
+			.it('should create account', (output: any) => {
+				expect(JSON.parse(output.stdout)).to.be.eql([
+					{
+						publicKey: cryptography.getKeys(defaultMnemonic).publicKey.toString('hex'),
+						privateKey: cryptography.getKeys(defaultMnemonic).privateKey.toString('hex'),
+						address: cryptography.getBase32AddressFromPublicKey(
+							cryptography.getKeys(defaultMnemonic).publicKey,
+							'lsk',
+						),
+						binaryAddress: cryptography.getAddressFromPassphrase(defaultMnemonic).toString('hex'),
+						passphrase: defaultMnemonic,
+					},
+				]);
+			});
+	});
+
+	describe('account:create --number=x', () => {
+		const defaultNumber = 2;
+		setupTest()
+			.command(['account:create', `--number=${defaultNumber}`])
+			.it('should create account', (output: any) => {
+				const result = [
+					{
+						publicKey: cryptography.getKeys(defaultMnemonic).publicKey.toString('hex'),
+						privateKey: cryptography.getKeys(defaultMnemonic).privateKey.toString('hex'),
+						address: cryptography.getBase32AddressFromPublicKey(
+							cryptography.getKeys(defaultMnemonic).publicKey,
+							'lsk',
+						),
+						binaryAddress: cryptography.getAddressFromPassphrase(defaultMnemonic).toString('hex'),
+						passphrase: defaultMnemonic,
+					},
+					{
+						publicKey: cryptography.getKeys(secondDefaultMnemonic).publicKey.toString('hex'),
+						privateKey: cryptography.getKeys(secondDefaultMnemonic).privateKey.toString('hex'),
+						address: cryptography.getBase32AddressFromPublicKey(
+							cryptography.getKeys(secondDefaultMnemonic).publicKey,
+							'lsk',
+						),
+						binaryAddress: cryptography
+							.getAddressFromPassphrase(secondDefaultMnemonic)
+							.toString('hex'),
+						passphrase: secondDefaultMnemonic,
+					},
+				];
+				expect(JSON.parse(output.stdout)).to.eql(result);
+			});
+
+		setupTest()
+			.command(['account:create', '--number=NaN'])
+			.catch((error: Error) => {
+				return expect(error.message).to.contain(
+					'Number flag must be an integer and greater than 0',
+				);
+			})
+			.it('should throw an error if the flag is invalid number');
+
+		setupTest()
+			.command(['account:create', '--number=0'])
+			.catch((error: Error) => {
+				return expect(error.message).to.contain(
+					'Number flag must be an integer and greater than 0',
+				);
+			})
+			.it('should throw an error if the number flag is less than 1');
+
+		setupTest()
+			.command(['account:create', '--number=10sk24'])
+			.catch((error: Error) => {
+				return expect(error.message).to.contain(
+					'Number flag must be an integer and greater than 0',
+				);
+			})
+			.it('should throw an error if the number flag contains non-number characters');
+	});
+});

--- a/test/commands/account/show.spec.ts
+++ b/test/commands/account/show.spec.ts
@@ -1,0 +1,65 @@
+/*
+ * LiskHQ/lisk-commander
+ * Copyright © 2019 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import * as sandbox from 'sinon';
+import { expect, test } from '@oclif/test';
+import { cryptography } from 'lisk-sdk';
+import * as readerUtils from '../../../src/utils/reader';
+
+describe('account:show', () => {
+	const passphraseInput =
+		'whale acoustic sword work scene frame assume ensure hawk federal upgrade angry';
+	const secondDefaultMnemonic =
+		'alone cabin buffalo blast region upper jealous basket brush put answer twice';
+
+	const setupTest = () =>
+		test.stub(readerUtils, 'getPassphraseFromPrompt', sandbox.stub().resolves(passphraseInput));
+
+	describe('account:show', () => {
+		setupTest()
+			.stdout()
+			.command(['account:show'])
+			.it('should show account with prompt', (output: any) => {
+				expect(readerUtils.getPassphraseFromPrompt).to.be.calledWithExactly('passphrase', true);
+				return expect(JSON.parse(output.stdout)).to.eql({
+					privateKey: cryptography.getKeys(passphraseInput).privateKey.toString('hex'),
+					publicKey: cryptography.getKeys(passphraseInput).publicKey.toString('hex'),
+					address: cryptography.getBase32AddressFromPublicKey(
+						cryptography.getKeys(passphraseInput).publicKey,
+						'lsk',
+					),
+					binaryAddress: cryptography.getAddressFromPassphrase(passphraseInput).toString('hex'),
+				});
+			});
+
+		setupTest()
+			.stdout()
+			.command(['account:show', `--passphrase=${secondDefaultMnemonic}`])
+			.it('should show account with pass', (output: any) => {
+				expect(readerUtils.getPassphraseFromPrompt).not.to.be.called;
+				return expect(JSON.parse(output.stdout)).to.eql({
+					privateKey: cryptography.getKeys(secondDefaultMnemonic).privateKey.toString('hex'),
+					publicKey: cryptography.getKeys(secondDefaultMnemonic).publicKey.toString('hex'),
+					address: cryptography.getBase32AddressFromPublicKey(
+						cryptography.getKeys(secondDefaultMnemonic).publicKey,
+						'lsk',
+					),
+					binaryAddress: cryptography
+						.getAddressFromPassphrase(secondDefaultMnemonic)
+						.toString('hex'),
+				});
+			});
+	});
+});

--- a/test/commands/account/validate.spec.ts
+++ b/test/commands/account/validate.spec.ts
@@ -1,0 +1,38 @@
+/*
+ * LiskHQ/lisk-commander
+ * Copyright © 2019 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import { expect, test } from '@oclif/test';
+
+describe('account:validate', () => {
+	const validAddress = 'lskso9zqyapuhu8kv7txfbohwrhjfbd4gkxewcuxz';
+	const invalidAddress = validAddress.replace('wr', 'om');
+
+	// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+	const setupTest = () => test.stdout();
+
+	describe('account:validate', () => {
+		setupTest()
+			.command(['account:validate', validAddress])
+			.it('should show address is valid', (output: any) => {
+				expect(output.stdout).to.contain('is a valid address');
+			});
+
+		setupTest()
+			.stdout()
+			.command(['account:validate', invalidAddress])
+			.catch(err => expect(err.message).to.contain('Invalid checksum for address'))
+			.it('should show address is invalid');
+	});
+});


### PR DESCRIPTION
### What was the problem?

This PR resolves #337 and resolves #341 

### How was it solved?

- Migrate create and show command from commander (src and test)
- Add validate command 

### How was it tested?

```
./bin/run account:create
./bin/run account:create -n 2
./bin/run account:show
./bin/run account:validate lskso9zqyapuhu8kv7txfbohwrhjfbd4gkxewcuxz
```
