### PR TITLE
Add config show command - Closes #262

### DIFF
--- a/src/commands/config/show.ts
+++ b/src/commands/config/show.ts
@@ -20,7 +20,7 @@ import {
 	splitPath,
 	getConfigDirs,
 	getNetworkConfigFilesPath,
-} from '../..//utils/path';
+} from '../../utils/path';
 import { flags as commonFlags } from '../../utils/flags';
 
 export default class ShowCommand extends Command {

--- a/src/commands/config/show.ts
+++ b/src/commands/config/show.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import { Command, flags as flagParser } from '@oclif/command';
+import * as fs from 'fs-extra';
+import { ApplicationConfig, utils } from 'lisk-sdk';
+import {
+	getDefaultPath,
+	splitPath,
+	getConfigDirs,
+	getNetworkConfigFilesPath,
+} from '../..//utils/path';
+import { flags as commonFlags } from '../../utils/flags';
+
+export default class ShowCommand extends Command {
+	static description = 'Show the config used to run an application on data path';
+
+	static examples = ['config:show', 'config:show --config ./custom-config.json --data-path ./data'];
+
+	static flags = {
+		'data-path': flagParser.string({
+			...commonFlags.dataPath,
+			env: 'LISK_DATA_PATH',
+		}),
+		config: flagParser.string({
+			char: 'c',
+			description:
+				'File path to a custom config. Environment variable "LISK_CONFIG_FILE" can also be used.',
+			env: 'LISK_CONFIG_FILE',
+		}),
+		pretty: flagParser.boolean({
+			description: 'Prints JSON in pretty format rather than condensed.',
+		}),
+	};
+
+	async run(): Promise<void> {
+		const { flags } = this.parse(ShowCommand);
+		const dataPath = flags['data-path'] ? flags['data-path'] : getDefaultPath();
+		const pathConfig = splitPath(dataPath);
+
+		// Validate dataPath/config if config for other network exists, throw error and exit unless overwrite-config is specified
+		const configDir = getConfigDirs(dataPath);
+		// If config file exist, do not copy unless overwrite-config is specified
+		if (configDir.length !== 1) {
+			this.error(`Folder in ${dataPath} does not contain valid config`);
+		}
+		// If genesis block file exist, do not copy unless overwrite-config is specified
+		const network = configDir[0];
+
+		// Read network genesis block and config from the folder
+		const { configFilePath } = getNetworkConfigFilesPath(dataPath, network);
+		// Get config from network config or config specifeid
+		let config = await fs.readJSON(configFilePath);
+
+		if (flags.config) {
+			const customConfig: ApplicationConfig = await fs.readJSON(flags.config);
+			config = utils.objects.mergeDeep({}, config, customConfig) as ApplicationConfig;
+		}
+
+		config.rootPath = pathConfig.rootPath;
+		config.label = pathConfig.label;
+		config.version = this.config.pjson.version;
+
+		if (flags.pretty) {
+			this.log(JSON.stringify(config, undefined, '  '));
+		} else {
+			this.log(JSON.stringify(config));
+		}
+	}
+}

--- a/test/commands/config/show.spec.ts
+++ b/test/commands/config/show.spec.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import { expect, test } from '@oclif/test';
+import * as sandbox from 'sinon';
+import * as fs from 'fs-extra';
+import * as os from 'os';
+
+describe('config:show command', () => {
+	const readJSONStub = sandbox.stub().resolves({
+		network: { port: 3000 },
+		logger: {
+			consoleLogLevel: 'error',
+		},
+	});
+	const readDirSync = sandbox.stub().returns(['mainnet']);
+	readDirSync.withArgs('new-folder/config').returns([]);
+	const setupTest = () =>
+		test
+			.stub(fs, 'readJSON', readJSONStub)
+			.stub(fs, 'ensureDirSync', sandbox.stub())
+			.stub(fs, 'statSync', sandbox.stub().returns({ isDirectory: () => true }))
+			.stub(fs, 'removeSync', sandbox.stub().returns(null))
+			.stub(fs, 'readdirSync', readDirSync)
+			.stub(os, 'homedir', sandbox.stub().returns('~'))
+			.stdout();
+
+	describe('config:show', () => {
+		setupTest()
+			.command(['config:show'])
+			.it('should get the config from default path', out => {
+				expect(JSON.parse(out.stdout).network.port).to.eql(3000);
+			});
+	});
+
+	describe('config:show -d ./new-folder', () => {
+		setupTest()
+			.command(['config:show', '-d', './new-folder'])
+			.catch(err => expect(err.message).to.contain('does not contain valid config'))
+			.it('should throw an error if the data path does not contain config');
+	});
+
+	describe('config:show -d ./config', () => {
+		setupTest()
+			.command(['config:show', '-d', './existing'])
+			.it('should get the config from specified data path', () => {
+				expect(fs.readdirSync).to.have.been.calledWith('existing/config');
+				expect(fs.readJSON).to.have.been.calledWith('existing/config/mainnet/config.json');
+			});
+	});
+
+	describe('config:show -c ./constom-config.json', () => {
+		const configPath = './custom-config.json';
+
+		const customConfig = { network: { port: 9999 } };
+
+		setupTest()
+			.stub(fs, 'readJSON', sandbox.stub().withArgs(customConfig).resolves(customConfig))
+			.command(['config:show', '-c', configPath])
+			.it('should overwrite the config with provided custom config', out => {
+				expect(JSON.parse(out.stdout).network.port).to.eql(9999);
+			});
+	});
+});

--- a/test/commands/sdk/link.spec.ts
+++ b/test/commands/sdk/link.spec.ts
@@ -1,3 +1,17 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
 import { expect, test } from '@oclif/test';
 import * as sandbox from 'sinon';
 import * as fs from 'fs-extra';


### PR DESCRIPTION
### What was the problem?

This PR resolves #262 

### How was it solved?

- Add config show command to show the config stored in the data path

### How was it tested?

- Added unit tests
```
./bin/run config:show
./bin/run config:show -d ./data-folder
./bin/run config:show -c ./custom-config.json
```
