### PR TITLE
Add offline flag to transaction:create and transaction:sign commands - Closes #318

### DIFF
--- a/src/base_ipc.ts
+++ b/src/base_ipc.ts
@@ -116,7 +116,7 @@ export default abstract class BaseIPCCommand extends Command {
 			await this._createIPCChannel(dataPath);
 			this._schema = await this._channel.invoke('app:getSchema');
 		}
-		await this._setCodec();
+		this._setCodec();
 	}
 
 	printJSON(message?: string | Record<string, unknown>): void {
@@ -146,10 +146,10 @@ export default abstract class BaseIPCCommand extends Command {
 		await this._channel.startAndListen();
 	}
 
-	private async _setCodec(): Promise<void> {
+	private _setCodec(): void {
 		this._codec = {
 			decodeAccount: (data: Buffer | string): Record<string, unknown> =>
-				codec.decodeJSON(this._schema.account, convertStrToBuffer(data)),
+				codec.decodeJSON<Record<string, unknown>>(this._schema.account, convertStrToBuffer(data)),
 			decodeBlock: (data: Buffer | string): Record<string, unknown> => {
 				const blockBuffer: Buffer = Buffer.isBuffer(data) ? data : Buffer.from(data, 'hex');
 				const {

--- a/src/commands/blockchain/download.ts
+++ b/src/commands/blockchain/download.ts
@@ -17,6 +17,7 @@ import { NETWORK, RELEASE_URL, DEFAULT_NETWORK } from '../../constants';
 import { liskSnapshotUrl } from '../../utils/commons';
 import { getFullPath } from '../../utils/path';
 import { downloadAndValidate } from '../../utils/download';
+import { flags as commonFlags } from '../../utils/flags';
 
 export default class DownloadCommand extends Command {
 	static description = 'Download blockchain data from a provided snapshot.';
@@ -29,9 +30,7 @@ export default class DownloadCommand extends Command {
 
 	static flags = {
 		network: flagParser.string({
-			char: 'n',
-			description:
-				'Default network config to use. Environment variable "LISK_NETWORK" can also be used.',
+			...commonFlags.network,
 			env: 'LISK_NETWORK',
 			default: DEFAULT_NETWORK,
 		}),

--- a/src/commands/config/show.ts
+++ b/src/commands/config/show.ts
@@ -60,7 +60,7 @@ export default class ShowCommand extends Command {
 
 		// Read network genesis block and config from the folder
 		const { configFilePath } = getNetworkConfigFilesPath(dataPath, network);
-		// Get config from network config or config specifeid
+		// Get config from network config or config specified
 		let config = await fs.readJSON(configFilePath);
 
 		if (flags.config) {

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -22,10 +22,10 @@ import {
 	splitPath,
 	getFullPath,
 	getConfigDirs,
-	getNetworkConfigFilesPath,
 	removeConfigDir,
 	ensureConfigDir,
 	getDefaultConfigDir,
+	getNetworkConfigFilesPath,
 	getDefaultNetworkConfigFilesPath,
 } from '../utils/path';
 import { flags as commonFlags } from '../utils/flags';
@@ -45,9 +45,7 @@ export default class StartCommand extends Command {
 			env: 'LISK_DATA_PATH',
 		}),
 		network: flagParser.string({
-			char: 'n',
-			description:
-				'Default network config to use. Environment variable "LISK_NETWORK" can also be used.',
+			...commonFlags.network,
 			env: 'LISK_NETWORK',
 			default: DEFAULT_NETWORK,
 		}),
@@ -184,7 +182,7 @@ export default class StartCommand extends Command {
 			fs.copyFileSync(defaultConfigFilepath, configFilePath);
 		}
 
-		// Get config from network config or config specifeid
+		// Get config from network config or config specified
 		const genesisBlock = await fs.readJSON(genesisBlockFilePath);
 		let config = await fs.readJSON(configFilePath);
 

--- a/src/commands/transaction/create.ts
+++ b/src/commands/transaction/create.ts
@@ -108,8 +108,8 @@ export default class CreateCommand extends BaseIPCCommand {
 		} = this.parse(CreateCommand);
 		const { fee, moduleID, assetID } = args as Args;
 
-		if (offline && !dataPath) {
-			throw new Error('Flag: --data-path must be specified while creating transaction offline.');
+		if (offline && dataPath) {
+			throw new Error('Flag: --data-path should not be specified while creating transaction offline.');
 		}
 
 		if (!senderPublicKeySource && noSignature) {

--- a/src/commands/transaction/create.ts
+++ b/src/commands/transaction/create.ts
@@ -109,7 +109,9 @@ export default class CreateCommand extends BaseIPCCommand {
 		const { fee, moduleID, assetID } = args as Args;
 
 		if (offline && dataPath) {
-			throw new Error('Flag: --data-path should not be specified while creating transaction offline.');
+			throw new Error(
+				'Flag: --data-path should not be specified while creating transaction offline.',
+			);
 		}
 
 		if (!senderPublicKeySource && noSignature) {

--- a/src/commands/transaction/create.ts
+++ b/src/commands/transaction/create.ts
@@ -19,6 +19,7 @@ import { codec, cryptography, transactions, validator } from 'lisk-sdk';
 import BaseIPCCommand from '../../base_ipc';
 import { flags as commonFlags } from '../../utils/flags';
 import { getAssetFromPrompt, getPassphraseFromPrompt } from '../../utils/reader';
+import { DEFAULT_NETWORK } from '../../constants';
 
 interface Args {
 	readonly nonce: string;
@@ -86,6 +87,14 @@ export default class CreateCommand extends BaseIPCCommand {
 		json: flagParser.boolean({
 			char: 'j',
 			description: 'Print the transaction in JSON format',
+		}),
+		offline: flagParser.boolean({
+			...commonFlags.offline,
+			hidden: false,
+		}),
+		network: flagParser.string({
+			...commonFlags.network,
+			hidden: false,
 		}),
 	};
 

--- a/src/commands/transaction/sign.ts
+++ b/src/commands/transaction/sign.ts
@@ -92,8 +92,8 @@ export default class SignCommand extends BaseIPCCommand {
 			},
 		} = this.parse(SignCommand);
 
-		if (offline && !dataPath) {
-			throw new Error('Flag: --data-path must be specified while signing offline.');
+		if (offline && dataPath) {
+			throw new Error('Flag: --data-path should not be specified while signing offline.');
 		}
 
 		if (offline && !networkIdentifierSource) {

--- a/src/commands/transaction/sign.ts
+++ b/src/commands/transaction/sign.ts
@@ -18,6 +18,7 @@ import { transactions, codec, TransactionJSON } from 'lisk-sdk';
 import BaseIPCCommand from '../../base_ipc';
 import { flags as commonFlags } from '../../utils/flags';
 import { getPassphraseFromPrompt } from '../../utils/reader';
+import { DEFAULT_NETWORK } from '../../constants';
 
 export default class SignCommand extends BaseIPCCommand {
 	static description = 'Sign an encoded transaction.';
@@ -52,6 +53,14 @@ export default class SignCommand extends BaseIPCCommand {
 		json: flagParser.boolean({
 			char: 'j',
 			description: 'Print the transaction in JSON format.',
+		}),
+		offline: flagParser.boolean({
+			...commonFlags.offline,
+			hidden: false,
+		}),
+		network: flagParser.string({
+			...commonFlags.network,
+			hidden: false,
 		}),
 	};
 

--- a/src/commands/transaction/sign.ts
+++ b/src/commands/transaction/sign.ts
@@ -149,7 +149,7 @@ export default class SignCommand extends BaseIPCCommand {
 				passphrase,
 			);
 		} else if (offline) {
-			if (!mandatoryKeys.length || !optionalKeys.length) {
+			if (!mandatoryKeys.length && !optionalKeys.length) {
 				throw new Error(
 					'--mandatory-keys or --optional-keys flag must be specified to sign transaction from multi signature account.',
 				);

--- a/src/utils/flags.ts
+++ b/src/utils/flags.ts
@@ -80,4 +80,7 @@ export const flags: FlagMap = {
 		description:
 			'Default network config to use. Environment variable "LISK_NETWORK" can also be used.',
 	},
+	networkIdentifier: {
+		description: 'Network identifier defined for the network or main | test for the Lisk Network.',
+	},
 };

--- a/src/utils/flags.ts
+++ b/src/utils/flags.ts
@@ -72,4 +72,12 @@ export const flags: FlagMap = {
 		description:
 			'Directory path to specify where node data is stored. Environment variable "LISK_DATA_PATH" can also be used.',
 	},
+	offline: {
+		description: 'Create and sign transaction without connecting to a local node.',
+	},
+	network: {
+		char: 'n',
+		description:
+			'Default network config to use. Environment variable "LISK_NETWORK" can also be used.',
+	},
 };

--- a/src/utils/flags.ts
+++ b/src/utils/flags.ts
@@ -73,7 +73,7 @@ export const flags: FlagMap = {
 			'Directory path to specify where node data is stored. Environment variable "LISK_DATA_PATH" can also be used.',
 	},
 	offline: {
-		description: 'Create and sign transaction without connecting to a local node.',
+		description: 'Specify whether to connect to a local node or not.',
 	},
 	network: {
 		char: 'n',

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -16,7 +16,7 @@
 import * as path from 'path';
 import * as fs from 'fs-extra';
 import * as os from 'os';
-import { systemDirs } from 'lisk-sdk';
+import { systemDirs, ApplicationConfig } from 'lisk-sdk';
 
 const defaultDir = '.lisk';
 const defaultFolder = 'default';
@@ -63,6 +63,19 @@ export const getConfigDirs = (dataPath: string): string[] => {
 	fs.ensureDirSync(configPath);
 	const files = fs.readdirSync(configPath);
 	return files.filter(file => fs.statSync(path.join(configPath, file)).isDirectory());
+};
+
+export const getGenesisBlockAndConfig = async (network: string) => {
+	const {
+		genesisBlockFilePath: defaultGenesisBlockFilePath,
+		configFilePath: defaultConfigFilepath,
+	} = getDefaultNetworkConfigFilesPath(network);
+
+	// Get config from network config or config specified
+	const genesisBlock: Record<string, unknown> = await fs.readJSON(defaultGenesisBlockFilePath);
+	const config: ApplicationConfig = await fs.readJSON(defaultConfigFilepath);
+
+	return { genesisBlock, config };
 };
 
 export const removeConfigDir = (dataPath: string, network: string): void =>

--- a/test/commands/start.spec.ts
+++ b/test/commands/start.spec.ts
@@ -100,7 +100,7 @@ describe('start', () => {
 			});
 	});
 
-	describe('when unknown network is specidied', () => {
+	describe('when unknown network is specified', () => {
 		setupTest()
 			.command(['start', '--network=unknown'])
 			.catch(err =>

--- a/test/commands/transaction/create.spec.ts
+++ b/test/commands/transaction/create.spec.ts
@@ -22,7 +22,11 @@ import { cryptography, IPCChannel, transactionSchema } from 'lisk-sdk';
 import baseIPC from '../../../src/base_ipc';
 import * as appUtils from '../../../src/utils/application';
 import * as readerUtils from '../../../src/utils/reader';
-import { dposVoteAssetSchema, tokenTransferAssetSchema } from '../../utils/transactions';
+import {
+	dposVoteAssetSchema,
+	tokenTransferAssetSchema,
+	accountSchema,
+} from '../../utils/transactions';
 
 const transactionsAssets = [
 	{
@@ -41,6 +45,8 @@ const transferAsset =
 	'{"amount":100,"recipientAddress":"ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815","data":"send token"}';
 const voteAsset =
 	'{"votes":[{"delegateAddress":"ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815","amount":100},{"delegateAddress":"ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815","amount":-50}]}';
+const unVoteAsset =
+	'{"votes":[{"delegateAddress":"ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815","amount":-50}]}';
 const { publicKey } = cryptography.getAddressAndPublicKeyFromPassphrase(passphrase);
 const senderPublickey = publicKey.toString('hex');
 
@@ -55,10 +61,21 @@ describe('transaction:create command', () => {
 		data: 'send token',
 	});
 
-	ipcInvokeStub.withArgs('app:getSchema').resolves({
-		transaction: transactionSchema,
-		transactionsAssets,
-	});
+	ipcInvokeStub
+		.withArgs('app:getSchema')
+		.resolves({
+			transaction: transactionSchema,
+			transactionsAssets,
+			account: accountSchema,
+		})
+		.withArgs('app:getNodeInfo')
+		.resolves({
+			networkIdentifier: '873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3',
+		})
+		.withArgs('app:getAccount')
+		.resolves(
+			'0a14ab0041a7d3f7b2c290b5b834d46bdc7b7eb8581512050880c2d72f1a020800220208002a3b0a1a0a0a67656e657369735f3834180020850528003080a094a58d1d121d0a14ab0041a7d3f7b2c290b5b834d46bdc7b7eb858151080a094a58d1d',
+		);
 
 	afterEach(() => {
 		ipcInvokeStub.resetHistory();
@@ -82,282 +99,350 @@ describe('transaction:create command', () => {
 	describe('transaction:create', () => {
 		setupTest()
 			.command(['transaction:create'])
-			.catch((error: Error) => expect(error.message).to.contain('Missing 5 required args:'))
+			.catch((error: Error) => expect(error.message).to.contain('Missing 3 required args:'))
 			.it('should throw an error when no arguments are provided.');
 	});
 
-	describe('transaction:create 873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3', () => {
+	describe('transaction:create 2', () => {
 		setupTest()
-			.command([
-				'transaction:create',
-				'873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3',
-			])
-			.catch((error: Error) => expect(error.message).to.contain('Missing 4 required args:'))
+			.command(['transaction:create', '2'])
+			.catch((error: Error) => expect(error.message).to.contain('Missing 2 required args:'))
 			.it('should throw an error when fee, nonce and transaction type are provided.');
 	});
 
-	describe('transaction:create 873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3 100000000', () => {
+	describe('transaction:create 2 0', () => {
 		setupTest()
-			.command([
-				'transaction:create',
-				'873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3',
-				'100000000',
-			])
-			.catch((error: Error) => expect(error.message).to.contain('Missing 3 required args:'))
+			.command(['transaction:create', '2', '0'])
+			.catch((error: Error) => expect(error.message).to.contain('Missing 1 required arg:'))
 			.it('should throw an error when nonce and transaction type are provided.');
 	});
 
-	describe('transaction:create 873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3 100000000 2', () => {
+	describe('transaction:create 99999 0 100000000', () => {
 		setupTest()
-			.command([
-				'transaction:create',
-				'873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3',
-				'100000000',
-				'2',
-			])
-			.catch((error: Error) => expect(error.message).to.contain('Missing 2 required args:'))
-			.it('should throw an error when transaction moduleID and assetID are provided.');
-	});
-
-	describe('transaction:create 873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3 100000000 2 2', () => {
-		setupTest()
-			.command([
-				'transaction:create',
-				'873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3',
-				'100000000',
-				'2',
-				'2',
-			])
-			.catch((error: Error) => expect(error.message).to.contain('Missing 1 required arg:'))
-			.it('should throw an error when transaction assetID is not provided.');
-	});
-
-	describe('transaction:create 873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3 100000000 2 99999 0', () => {
-		setupTest()
-			.command([
-				'transaction:create',
-				'873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3',
-				'100000000',
-				'2',
-				'99999',
-				'0',
-			])
+			.command(['transaction:create', '99999', '0', '100000000'])
 			.catch((error: Error) =>
 				expect(error.message).to.contain(
 					'Transaction moduleID:99999 with assetID:0 is not registered in the application',
 				),
 			)
-			.it('should throw an error when transaction type is unknown.');
+			.it('should throw an error when moduleID is not registered.');
 	});
 
-	describe('transaction:create with flags', () => {
-		describe(`transaction:create 873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3 100000000 2 8 --asset='{"amount": "abc"}' --passphrase=${passphrase}`, () => {
-			setupTest()
-				.command([
-					'transaction:create',
-					'873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3',
-					'100000000',
-					'2',
-					'2',
-					'0',
-					'--asset={"amount": "abc"}',
-					`--passphrase=${passphrase}`,
-				])
-				.catch((error: Error) => expect(error.message).to.contain('Cannot convert abc to a BigInt'))
-				.it('should throw error for invalid asset.');
-		});
+	describe('offline', () => {
+		describe('with flags', () => {
+			describe(`transaction:create 2 0 100000000 --asset='{"amount": "abc"}' --passphrase=${passphrase} --offline`, () => {
+				setupTest()
+					.command([
+						'transaction:create',
+						'2',
+						'0',
+						'100000000',
+						'--asset={"amount": "abc"}',
+						`--passphrase=${passphrase}`,
+						'--offline',
+						'--network=devnet',
+					])
+					.catch((error: Error) =>
+						expect(error.message).to.contain(
+							'Flag: --data-path must be specified while creating transaction offline',
+						),
+					)
+					.it('should throw error for missing data path flag.');
+			});
 
-		describe(`transaction:create 873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3 100000000 2 8 --asset=${transferAsset} --no-signature`, () => {
-			setupTest()
-				.command([
-					'transaction:create',
-					'873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3',
-					'100000000',
-					'2',
-					'2',
-					'0',
-					`--asset=${transferAsset}`,
-					'--no-signature',
-				])
-				.catch((error: Error) =>
-					expect(error.message).to.contain(
-						'Sender publickey must be specified when no-signature flags is used',
-					),
-				)
-				.it(
-					'should throw error when sender publickey not specified when no-signature flag is used.',
-				);
-		});
+			describe(`transaction:create 2 0 100000000 --asset='{"amount": "abc"}' --passphrase=${passphrase} --offline`, () => {
+				setupTest()
+					.command([
+						'transaction:create',
+						'2',
+						'0',
+						'100000000',
+						'--asset={"amount": "abc"}',
+						`--passphrase=${passphrase}`,
+						'--offline',
+						'--data-path=/tmp',
+						'--network=devnet',
+					])
+					.catch((error: Error) =>
+						expect(error.message).to.contain(
+							'Flag: --network-identifier must be specified while creating transaction offline',
+						),
+					)
+					.it('should throw error for missing network identifier flag.');
+			});
 
-		describe(`transaction:create 873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3 100000000 2 8 --asset=${transferAsset} --passphrase=${passphrase}`, () => {
-			setupTest()
-				.command([
-					'transaction:create',
-					'873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3',
-					'100000000',
-					'2',
-					'2',
-					'0',
-					`--asset=${transferAsset}`,
-					`--passphrase=${passphrase}`,
-				])
-				.it('should return encoded transaction string in hex format with signature', () => {
-					expect(printJSONStub).to.be.calledOnce;
-					expect(printJSONStub).to.be.calledWithExactly({
-						transaction:
-							'0802100018022080c2d72f2a200fe9a3f1a21b5530f27f87a414b549e79a940bf24fdf2b2f05e7f22aeeecc86a322408641214ab0041a7d3f7b2c290b5b834d46bdc7b7eb858151a0a73656e6420746f6b656e3a40aeceacee0cc92d5cb35dc4c49237c54d089b61273ade9cfd5dca538ccbf577cdf513618205f6757102aa1cd9958fb94def8df5536bd993686b4aebf4e23f080f',
+			describe(`transaction:create 2 0 100000000 --asset='{"amount": "abc"}' --passphrase=${passphrase} --offline`, () => {
+				setupTest()
+					.command([
+						'transaction:create',
+						'2',
+						'0',
+						'100000000',
+						'--asset={"amount": "abc"}',
+						`--passphrase=${passphrase}`,
+						'--offline',
+						'--data-path=/tmp',
+						'--network=devnet',
+						'--network-identifier=873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3.',
+					])
+					.catch((error: Error) =>
+						expect(error.message).to.contain(
+							'Flag: --nonce must be specified while creating transaction offline',
+						),
+					)
+					.it('should throw error for missing nonce flag.');
+			});
+
+			describe(`transaction:create 2 0 100000000 --asset=${transferAsset} --no-signature`, () => {
+				setupTest()
+					.command([
+						'transaction:create',
+						'2',
+						'0',
+						'100000000',
+						`--asset=${transferAsset}`,
+						'--no-signature',
+						'--offline',
+						'--data-path=/tmp',
+						'--network-identifier=873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3.',
+						'--nonce=1',
+						'--network=devnet',
+					])
+					.catch((error: Error) =>
+						expect(error.message).to.contain(
+							'Sender publickey must be specified when no-signature flags is used',
+						),
+					)
+					.it(
+						'should throw error when sender publickey not specified when no-signature flag is used.',
+					);
+			});
+
+			describe(`transaction:create 2 0 100000000 --asset=${transferAsset} --passphrase=${passphrase}`, () => {
+				setupTest()
+					.command([
+						'transaction:create',
+						'2',
+						'0',
+						'100000000',
+						'--offline',
+						`--asset=${transferAsset}`,
+						`--passphrase=${passphrase}`,
+						'--data-path=/tmp',
+						'--network-identifier=873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3.',
+						'--nonce=1',
+						'--network=devnet',
+					])
+					.it('should return encoded transaction string in hex format with signature', () => {
+						expect(printJSONStub).to.be.calledOnce;
+						expect(printJSONStub).to.be.calledWithExactly({
+							transaction:
+								'0802100018012080c2d72f2a200fe9a3f1a21b5530f27f87a414b549e79a940bf24fdf2b2f05e7f22aeeecc86a322408641214ab0041a7d3f7b2c290b5b834d46bdc7b7eb858151a0a73656e6420746f6b656e3a40816039d55d0710f6b412e221b4fc0422a29d5314603c43eeafab0017e4c6bfbd575c5d53b2c0429992922737ec0f8add0767b904b80cfc411021bfdb0b04bc0a',
+						});
 					});
-				});
-		});
+			});
 
-		describe(`transaction:create 873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3 100000000 2 8 --asset=${transferAsset} --no-signature --sender-publickey=${senderPublickey}`, () => {
-			setupTest()
-				.command([
-					'transaction:create',
-					'873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3',
-					'100000000',
-					'2',
-					'2',
-					'0',
-					`--asset=${transferAsset}`,
-					'--no-signature',
-					`--sender-publickey=${senderPublickey}`,
-				])
-				.it('should return encoded transaction string in hex format without signature', () => {
-					expect(printJSONStub).to.be.calledOnce;
-					expect(printJSONStub).to.be.calledWithExactly({
-						transaction:
-							'0802100018022080c2d72f2a200fe9a3f1a21b5530f27f87a414b549e79a940bf24fdf2b2f05e7f22aeeecc86a322408641214ab0041a7d3f7b2c290b5b834d46bdc7b7eb858151a0a73656e6420746f6b656e',
+			describe(`transaction:create 2 0 100000000 --asset=${transferAsset} --no-signature --sender-publickey=${senderPublickey}`, () => {
+				setupTest()
+					.command([
+						'transaction:create',
+						'2',
+						'0',
+						'100000000',
+						'--offline',
+						`--asset=${transferAsset}`,
+						'--no-signature',
+						`--sender-publickey=${senderPublickey}`,
+						'--data-path=/tmp',
+						'--network-identifier=873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3.',
+						'--nonce=1',
+						'--network=devnet',
+					])
+					.it('should return encoded transaction string in hex format without signature', () => {
+						expect(printJSONStub).to.be.calledOnce;
+						expect(printJSONStub).to.be.calledWithExactly({
+							transaction:
+								'0802100018012080c2d72f2a200fe9a3f1a21b5530f27f87a414b549e79a940bf24fdf2b2f05e7f22aeeecc86a322408641214ab0041a7d3f7b2c290b5b834d46bdc7b7eb858151a0a73656e6420746f6b656e',
+						});
 					});
-				});
-		});
+			});
 
-		describe(`transaction:create 873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3 100000000 2 5 1 --asset=${voteAsset} --passphrase=${passphrase}`, () => {
-			setupTest()
-				.command([
-					'transaction:create',
-					'873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3',
-					'100000000',
-					'2',
-					'5',
-					'1',
-					`--asset=${voteAsset}`,
-					`--passphrase=${passphrase}`,
-				])
-				.it('should return encoded transaction string in hex format with signature', () => {
-					expect(printJSONStub).to.be.calledOnce;
-					expect(printJSONStub).to.be.calledWithExactly({
-						transaction:
-							'0805100118022080c2d72f2a200fe9a3f1a21b5530f27f87a414b549e79a940bf24fdf2b2f05e7f22aeeecc86a32350a190a14ab0041a7d3f7b2c290b5b834d46bdc7b7eb8581510c8010a180a14ab0041a7d3f7b2c290b5b834d46bdc7b7eb8581510633a407bc8953b3d598985cfaabf949576b82d314511ce6aeb81bad5d06c925538b953e0c5161b5f7c93fb320c52944c406ecf5ef6038b44b578d221495f4d36ae430e',
+			describe(`transaction:create 5 1 100000000 --asset=${voteAsset} --passphrase=${passphrase}`, () => {
+				setupTest()
+					.command([
+						'transaction:create',
+						'5',
+						'1',
+						'100000000',
+						'--offline',
+						`--asset=${voteAsset}`,
+						`--passphrase=${passphrase}`,
+						'--data-path=/tmp',
+						'--network-identifier=873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3.',
+						'--nonce=1',
+						'--network=devnet',
+					])
+					.it('should return encoded transaction string in hex format with signature', () => {
+						expect(printJSONStub).to.be.calledOnce;
+						expect(printJSONStub).to.be.calledWithExactly({
+							transaction:
+								'0805100118012080c2d72f2a200fe9a3f1a21b5530f27f87a414b549e79a940bf24fdf2b2f05e7f22aeeecc86a32350a190a14ab0041a7d3f7b2c290b5b834d46bdc7b7eb8581510c8010a180a14ab0041a7d3f7b2c290b5b834d46bdc7b7eb8581510633a40cf630a8bd820a4176bde1c9af65c316d020c3db012729d46d1fa5784e0f9b7eaa730dcc7ad603620c302f0855116398e8c9ba7a2a6ed54061e67fbf1f7c5100c',
+						});
 					});
-				});
-		});
+			});
 
-		describe(`transaction:create 873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3 100000000 2 5 1 --asset=${voteAsset} --passphrase=${passphrase}`, () => {
-			setupTest()
-				.command([
-					'transaction:create',
-					'873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3',
-					'100000000',
-					'2',
-					'5',
-					'1',
-					`--asset=${voteAsset}`,
-					`--passphrase=${passphrase}`,
-				])
-				.it('should return encoded transaction string in hex format with signature', () => {
-					expect(printJSONStub).to.be.calledOnce;
-					expect(printJSONStub).to.be.calledWithExactly({
-						transaction:
-							'0805100118022080c2d72f2a200fe9a3f1a21b5530f27f87a414b549e79a940bf24fdf2b2f05e7f22aeeecc86a32350a190a14ab0041a7d3f7b2c290b5b834d46bdc7b7eb8581510c8010a180a14ab0041a7d3f7b2c290b5b834d46bdc7b7eb8581510633a407bc8953b3d598985cfaabf949576b82d314511ce6aeb81bad5d06c925538b953e0c5161b5f7c93fb320c52944c406ecf5ef6038b44b578d221495f4d36ae430e',
+			describe(`transaction:create 5 1 100000000 --asset=${unVoteAsset} --passphrase=${passphrase}`, () => {
+				setupTest()
+					.command([
+						'transaction:create',
+						'5',
+						'1',
+						'100000000',
+						'--offline',
+						`--asset=${unVoteAsset}`,
+						`--passphrase=${passphrase}`,
+						'--data-path=/tmp',
+						'--network-identifier=873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3.',
+						'--nonce=1',
+						'--network=devnet',
+					])
+					.it('should return encoded transaction string in hex format with signature', () => {
+						expect(printJSONStub).to.be.calledOnce;
+						expect(printJSONStub).to.be.calledWithExactly({
+							transaction:
+								'0805100118012080c2d72f2a200fe9a3f1a21b5530f27f87a414b549e79a940bf24fdf2b2f05e7f22aeeecc86a321a0a180a14ab0041a7d3f7b2c290b5b834d46bdc7b7eb8581510633a4009da2349735f2bd71d2e013f261c1ff4a75091daed56521de4b55156a5c8802446574328c76a3168c5f912cdf59275f070c1a1904fec6e8ef3a021019a96820b',
+						});
 					});
-				});
+			});
 		});
-	});
 
-	describe('transaction:create with prompts and flags', () => {
-		describe(`transaction:create 873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3 100000000 2 2 0 --passphrase=${passphrase}`, () => {
-			setupTest()
-				.command([
-					'transaction:create',
-					'873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3',
-					'100000000',
-					'2',
-					'2',
-					'0',
-					`--passphrase=${passphrase}`,
-				])
-				.it('should prompt user for asset.', () => {
-					expect(promptAssetStub).to.be.calledOnce;
-					expect(promptAssetStub).to.be.calledWithExactly([
-						{ message: 'Please enter: amount: ', name: 'amount', type: 'input' },
-						{
-							message: 'Please enter: recipientAddress: ',
-							name: 'recipientAddress',
-							type: 'input',
+		describe('with prompts and flags', () => {
+			describe(`transaction:create 2 0 100000000 --passphrase=${passphrase}`, () => {
+				setupTest()
+					.command([
+						'transaction:create',
+						'2',
+						'0',
+						'100000000',
+						`--passphrase=${passphrase}`,
+						'--offline',
+						'--network=devnet',
+						'--data-path=/tmp',
+						'--network-identifier=873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3.',
+						'--nonce=1',
+					])
+					.it('should prompt user for asset.', () => {
+						expect(promptAssetStub).to.be.calledOnce;
+						expect(promptAssetStub).to.be.calledWithExactly([
+							{ message: 'Please enter: amount: ', name: 'amount', type: 'input' },
+							{
+								message: 'Please enter: recipientAddress: ',
+								name: 'recipientAddress',
+								type: 'input',
+							},
+							{ message: 'Please enter: data: ', name: 'data', type: 'input' },
+						]);
+						expect(printJSONStub).to.be.calledOnce;
+						expect(printJSONStub).to.be.calledWithExactly({
+							transaction:
+								'0802100018012080c2d72f2a200fe9a3f1a21b5530f27f87a414b549e79a940bf24fdf2b2f05e7f22aeeecc86a322408641214ab0041a7d3f7b2c290b5b834d46bdc7b7eb858151a0a73656e6420746f6b656e3a40816039d55d0710f6b412e221b4fc0422a29d5314603c43eeafab0017e4c6bfbd575c5d53b2c0429992922737ec0f8add0767b904b80cfc411021bfdb0b04bc0a',
+						});
+					});
+			});
+
+			describe('transaction:create 2 0 100000000 ', () => {
+				setupTest()
+					.command([
+						'transaction:create',
+						'2',
+						'0',
+						'100000000',
+						'--offline',
+						'--network=devnet',
+						'--data-path=/tmp',
+						'--network-identifier=873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3.',
+						'--nonce=1',
+					])
+					.it('should prompt user for asset and passphrase.', () => {
+						expect(promptAssetStub).to.be.calledOnce;
+						expect(promptAssetStub).to.be.calledWithExactly([
+							{ message: 'Please enter: amount: ', name: 'amount', type: 'input' },
+							{
+								message: 'Please enter: recipientAddress: ',
+								name: 'recipientAddress',
+								type: 'input',
+							},
+							{ message: 'Please enter: data: ', name: 'data', type: 'input' },
+						]);
+						expect(readerUtils.getPassphraseFromPrompt).to.be.calledWithExactly('passphrase', true);
+						expect(printJSONStub).to.be.calledOnce;
+						expect(printJSONStub).to.be.calledWithExactly({
+							transaction:
+								'0802100018012080c2d72f2a200fe9a3f1a21b5530f27f87a414b549e79a940bf24fdf2b2f05e7f22aeeecc86a322408641214ab0041a7d3f7b2c290b5b834d46bdc7b7eb858151a0a73656e6420746f6b656e3a40816039d55d0710f6b412e221b4fc0422a29d5314603c43eeafab0017e4c6bfbd575c5d53b2c0429992922737ec0f8add0767b904b80cfc411021bfdb0b04bc0a',
+						});
+					});
+			});
+
+			describe(`transaction:create 2 0 100000000 --asset=${transferAsset} --no-signature --json`, () => {
+				setupTest()
+					.command([
+						'transaction:create',
+						'2',
+						'0',
+						'100000000',
+						`--asset=${transferAsset}`,
+						'--no-signature',
+						`--sender-publickey=${senderPublickey}`,
+						'--json',
+						'--offline',
+						'--network=devnet',
+						'--data-path=/tmp',
+						'--network-identifier=873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3.',
+						'--nonce=1',
+					])
+					.it(
+						'should return unsigned transaction in json format when no passphrase specified',
+						() => {
+							expect(printJSONStub).to.be.calledOnce;
+							expect(printJSONStub).to.be.calledWithExactly({
+								moduleID: 2,
+								assetID: 0,
+								nonce: '1',
+								fee: '100000000',
+								senderPublicKey: '0fe9a3f1a21b5530f27f87a414b549e79a940bf24fdf2b2f05e7f22aeeecc86a',
+								asset: {
+									amount: '100',
+									data: 'send token',
+									recipientAddress: 'ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815',
+								},
+								signatures: [],
+							});
 						},
-						{ message: 'Please enter: data: ', name: 'data', type: 'input' },
-					]);
-					expect(printJSONStub).to.be.calledOnce;
-					expect(printJSONStub).to.be.calledWithExactly({
-						transaction:
-							'0802100018022080c2d72f2a200fe9a3f1a21b5530f27f87a414b549e79a940bf24fdf2b2f05e7f22aeeecc86a322408641214ab0041a7d3f7b2c290b5b834d46bdc7b7eb858151a0a73656e6420746f6b656e3a40aeceacee0cc92d5cb35dc4c49237c54d089b61273ade9cfd5dca538ccbf577cdf513618205f6757102aa1cd9958fb94def8df5536bd993686b4aebf4e23f080f',
-					});
-				});
-		});
+					);
+			});
 
-		describe('transaction:create 873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3 100000000 2 2 0', () => {
-			setupTest()
-				.command([
-					'transaction:create',
-					'873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3',
-					'100000000',
-					'2',
-					'2',
-					'0',
-				])
-				.it('should prompt user for asset and passphrase.', () => {
-					expect(promptAssetStub).to.be.calledOnce;
-					expect(promptAssetStub).to.be.calledWithExactly([
-						{ message: 'Please enter: amount: ', name: 'amount', type: 'input' },
-						{
-							message: 'Please enter: recipientAddress: ',
-							name: 'recipientAddress',
-							type: 'input',
-						},
-						{ message: 'Please enter: data: ', name: 'data', type: 'input' },
-					]);
-					expect(readerUtils.getPassphraseFromPrompt).to.be.calledWithExactly('passphrase', true);
-					expect(printJSONStub).to.be.calledOnce;
-					expect(printJSONStub).to.be.calledWithExactly({
-						transaction:
-							'0802100018022080c2d72f2a200fe9a3f1a21b5530f27f87a414b549e79a940bf24fdf2b2f05e7f22aeeecc86a322408641214ab0041a7d3f7b2c290b5b834d46bdc7b7eb858151a0a73656e6420746f6b656e3a40aeceacee0cc92d5cb35dc4c49237c54d089b61273ade9cfd5dca538ccbf577cdf513618205f6757102aa1cd9958fb94def8df5536bd993686b4aebf4e23f080f',
-					});
-				});
-		});
-
-		describe(`transaction:create 873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3 100000000 2 2 0 --asset=${transferAsset} --no-signature --json`, () => {
-			setupTest()
-				.command([
-					'transaction:create',
-					'873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3',
-					'100000000',
-					'2',
-					'2',
-					'0',
-					`--asset=${transferAsset}`,
-					'--no-signature',
-					`--sender-publickey=${senderPublickey}`,
-					'--json',
-				])
-				.it(
-					'should return unsigned transaction in json format when no passphrase specified',
-					() => {
+			describe(`transaction:create 2 0 100000000 --asset=${transferAsset} --passphrase=${passphrase} --json`, () => {
+				setupTest()
+					.command([
+						'transaction:create',
+						'2',
+						'0',
+						'100000000',
+						`--asset=${transferAsset}`,
+						`--passphrase=${passphrase}`,
+						'--json',
+						'--offline',
+						'--network=devnet',
+						'--data-path=/tmp',
+						'--network-identifier=873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3.',
+						'--nonce=1',
+					])
+					.it('should return signed transaction in json format when passphrase specified', () => {
 						expect(printJSONStub).to.be.calledOnce;
 						expect(printJSONStub).to.be.calledWithExactly({
 							moduleID: 2,
 							assetID: 0,
-							nonce: '2',
+							nonce: '1',
 							fee: '100000000',
 							senderPublicKey: '0fe9a3f1a21b5530f27f87a414b549e79a940bf24fdf2b2f05e7f22aeeecc86a',
 							asset: {
@@ -365,43 +450,240 @@ describe('transaction:create command', () => {
 								data: 'send token',
 								recipientAddress: 'ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815',
 							},
-							signatures: [],
+							signatures: [
+								'816039d55d0710f6b412e221b4fc0422a29d5314603c43eeafab0017e4c6bfbd575c5d53b2c0429992922737ec0f8add0767b904b80cfc411021bfdb0b04bc0a',
+							],
 						});
-					},
-				);
+					});
+			});
+		});
+	});
+
+	describe('online', () => {
+		describe('with flags', () => {
+			describe(`transaction:create 2 0 100000000 --asset='{"amount": "abc"}' --passphrase=${passphrase}`, () => {
+				setupTest()
+					.command([
+						'transaction:create',
+						'2',
+						'0',
+						'100000000',
+						'--asset={"amount": "abc"}',
+						`--passphrase=${passphrase}`,
+					])
+					.catch((error: Error) =>
+						expect(error.message).to.contain('Cannot convert abc to a BigInt'),
+					)
+					.it('should throw error for invalid asset.');
+			});
+
+			describe(`transaction:create 2 0 100000000 --asset=${transferAsset} --no-signature`, () => {
+				setupTest()
+					.command([
+						'transaction:create',
+						'2',
+						'0',
+						'100000000',
+						`--asset=${transferAsset}`,
+						'--no-signature',
+					])
+					.catch((error: Error) =>
+						expect(error.message).to.contain(
+							'Sender publickey must be specified when no-signature flags is used',
+						),
+					)
+					.it(
+						'should throw error when sender publickey not specified when no-signature flag is used.',
+					);
+			});
+
+			describe(`transaction:create 2 0 100000000 --asset=${transferAsset} --passphrase=${passphrase}`, () => {
+				setupTest()
+					.command([
+						'transaction:create',
+						'2',
+						'0',
+						'100000000',
+						`--asset=${transferAsset}`,
+						`--passphrase=${passphrase}`,
+					])
+					.it('should return encoded transaction string in hex format with signature', () => {
+						expect(printJSONStub).to.be.calledOnce;
+						expect(printJSONStub).to.be.calledWithExactly({
+							transaction:
+								'0802100018002080c2d72f2a200fe9a3f1a21b5530f27f87a414b549e79a940bf24fdf2b2f05e7f22aeeecc86a322408641214ab0041a7d3f7b2c290b5b834d46bdc7b7eb858151a0a73656e6420746f6b656e3a403cc8c8c81097fe59d9df356b3c3f1dd10f619bfabb54f5d187866092c67e0102c64dbe24f357df493cc7ebacdd2e55995db8912245b718d88ebf7f4f4ac01f04',
+						});
+					});
+			});
+
+			describe(`transaction:create 2 0 100000000 --asset=${transferAsset} --no-signature --sender-publickey=${senderPublickey}`, () => {
+				setupTest()
+					.command([
+						'transaction:create',
+						'2',
+						'0',
+						'100000000',
+						`--asset=${transferAsset}`,
+						'--no-signature',
+						`--sender-publickey=${senderPublickey}`,
+					])
+					.it('should return encoded transaction string in hex format without signature', () => {
+						expect(printJSONStub).to.be.calledOnce;
+						expect(printJSONStub).to.be.calledWithExactly({
+							transaction:
+								'0802100018002080c2d72f2a200fe9a3f1a21b5530f27f87a414b549e79a940bf24fdf2b2f05e7f22aeeecc86a322408641214ab0041a7d3f7b2c290b5b834d46bdc7b7eb858151a0a73656e6420746f6b656e',
+						});
+					});
+			});
+
+			describe(`transaction:create 5 1 100000000 --asset=${voteAsset} --passphrase=${passphrase}`, () => {
+				setupTest()
+					.command([
+						'transaction:create',
+						'5',
+						'1',
+						'100000000',
+						`--asset=${voteAsset}`,
+						`--passphrase=${passphrase}`,
+					])
+					.it('should return encoded transaction string in hex format with signature', () => {
+						expect(printJSONStub).to.be.calledOnce;
+						expect(printJSONStub).to.be.calledWithExactly({
+							transaction:
+								'0805100118002080c2d72f2a200fe9a3f1a21b5530f27f87a414b549e79a940bf24fdf2b2f05e7f22aeeecc86a32350a190a14ab0041a7d3f7b2c290b5b834d46bdc7b7eb8581510c8010a180a14ab0041a7d3f7b2c290b5b834d46bdc7b7eb8581510633a40d8d475f98d02508e410c735934f6db047bf99e22094f13fe24281b066d4fc725885f696e4e929320700117e01b1baa7251dd8639d194032c9ad9af93d5d6c50f',
+						});
+					});
+			});
+
+			describe(`transaction:create 5 1 100000000 --asset=${unVoteAsset} --passphrase=${passphrase}`, () => {
+				setupTest()
+					.command([
+						'transaction:create',
+						'5',
+						'1',
+						'100000000',
+						`--asset=${unVoteAsset}`,
+						`--passphrase=${passphrase}`,
+					])
+					.it('should return encoded transaction string in hex format with signature', () => {
+						expect(printJSONStub).to.be.calledOnce;
+						expect(printJSONStub).to.be.calledWithExactly({
+							transaction:
+								'0805100118002080c2d72f2a200fe9a3f1a21b5530f27f87a414b549e79a940bf24fdf2b2f05e7f22aeeecc86a321a0a180a14ab0041a7d3f7b2c290b5b834d46bdc7b7eb8581510633a40cb9d17b605f2711accaba4759a4e99c4b1ece97da0220603af9e8fd9aa88e01cd45dbca9aaad7fee61f6ef622149057b0189a4ab9ab5a9bc3e1a2bdad302d104',
+						});
+					});
+			});
 		});
 
-		describe(`transaction:create 873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3 100000000 2 2 0 --asset=${transferAsset} --passphrase=${passphrase} --json`, () => {
-			setupTest()
-				.command([
-					'transaction:create',
-					'873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3',
-					'100000000',
-					'2',
-					'2',
-					'0',
-					`--asset=${transferAsset}`,
-					`--passphrase=${passphrase}`,
-					'--json',
-				])
-				.it('should return signed transaction in json format when passphrase specified', () => {
-					expect(printJSONStub).to.be.calledOnce;
-					expect(printJSONStub).to.be.calledWithExactly({
-						moduleID: 2,
-						assetID: 0,
-						nonce: '2',
-						fee: '100000000',
-						senderPublicKey: '0fe9a3f1a21b5530f27f87a414b549e79a940bf24fdf2b2f05e7f22aeeecc86a',
-						asset: {
-							amount: '100',
-							data: 'send token',
-							recipientAddress: 'ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815',
-						},
-						signatures: [
-							'aeceacee0cc92d5cb35dc4c49237c54d089b61273ade9cfd5dca538ccbf577cdf513618205f6757102aa1cd9958fb94def8df5536bd993686b4aebf4e23f080f',
-						],
+		describe('with prompts and flags', () => {
+			describe(`transaction:create 2 0 100000000 --passphrase=${passphrase}`, () => {
+				setupTest()
+					.command(['transaction:create', '2', '0', '100000000', `--passphrase=${passphrase}`])
+					.it('should prompt user for asset.', () => {
+						expect(promptAssetStub).to.be.calledOnce;
+						expect(promptAssetStub).to.be.calledWithExactly([
+							{ message: 'Please enter: amount: ', name: 'amount', type: 'input' },
+							{
+								message: 'Please enter: recipientAddress: ',
+								name: 'recipientAddress',
+								type: 'input',
+							},
+							{ message: 'Please enter: data: ', name: 'data', type: 'input' },
+						]);
+						expect(printJSONStub).to.be.calledOnce;
+						expect(printJSONStub).to.be.calledWithExactly({
+							transaction:
+								'0802100018002080c2d72f2a200fe9a3f1a21b5530f27f87a414b549e79a940bf24fdf2b2f05e7f22aeeecc86a322408641214ab0041a7d3f7b2c290b5b834d46bdc7b7eb858151a0a73656e6420746f6b656e3a403cc8c8c81097fe59d9df356b3c3f1dd10f619bfabb54f5d187866092c67e0102c64dbe24f357df493cc7ebacdd2e55995db8912245b718d88ebf7f4f4ac01f04',
+						});
 					});
-				});
+			});
+
+			describe('transaction:create 2 0 100000000 ', () => {
+				setupTest()
+					.command(['transaction:create', '2', '0', '100000000'])
+					.it('should prompt user for asset and passphrase.', () => {
+						expect(promptAssetStub).to.be.calledOnce;
+						expect(promptAssetStub).to.be.calledWithExactly([
+							{ message: 'Please enter: amount: ', name: 'amount', type: 'input' },
+							{
+								message: 'Please enter: recipientAddress: ',
+								name: 'recipientAddress',
+								type: 'input',
+							},
+							{ message: 'Please enter: data: ', name: 'data', type: 'input' },
+						]);
+						expect(readerUtils.getPassphraseFromPrompt).to.be.calledWithExactly('passphrase', true);
+						expect(printJSONStub).to.be.calledOnce;
+						expect(printJSONStub).to.be.calledWithExactly({
+							transaction:
+								'0802100018002080c2d72f2a200fe9a3f1a21b5530f27f87a414b549e79a940bf24fdf2b2f05e7f22aeeecc86a322408641214ab0041a7d3f7b2c290b5b834d46bdc7b7eb858151a0a73656e6420746f6b656e3a403cc8c8c81097fe59d9df356b3c3f1dd10f619bfabb54f5d187866092c67e0102c64dbe24f357df493cc7ebacdd2e55995db8912245b718d88ebf7f4f4ac01f04',
+						});
+					});
+			});
+
+			describe(`transaction:create 2 0 100000000 --asset=${transferAsset} --no-signature --json`, () => {
+				setupTest()
+					.command([
+						'transaction:create',
+						'2',
+						'0',
+						'100000000',
+						`--asset=${transferAsset}`,
+						'--no-signature',
+						`--sender-publickey=${senderPublickey}`,
+						'--json',
+					])
+					.it(
+						'should return unsigned transaction in json format when no passphrase specified',
+						() => {
+							expect(printJSONStub).to.be.calledOnce;
+							expect(printJSONStub).to.be.calledWithExactly({
+								moduleID: 2,
+								assetID: 0,
+								nonce: '0',
+								fee: '100000000',
+								senderPublicKey: '0fe9a3f1a21b5530f27f87a414b549e79a940bf24fdf2b2f05e7f22aeeecc86a',
+								asset: {
+									amount: '100',
+									data: 'send token',
+									recipientAddress: 'ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815',
+								},
+								signatures: [],
+							});
+						},
+					);
+			});
+
+			describe(`transaction:create 2 0 100000000 --asset=${transferAsset} --passphrase=${passphrase} --json`, () => {
+				setupTest()
+					.command([
+						'transaction:create',
+						'2',
+						'0',
+						'100000000',
+						`--asset=${transferAsset}`,
+						`--passphrase=${passphrase}`,
+						'--json',
+					])
+					.it('should return signed transaction in json format when passphrase specified', () => {
+						expect(printJSONStub).to.be.calledOnce;
+						expect(printJSONStub).to.be.calledWithExactly({
+							moduleID: 2,
+							assetID: 0,
+							nonce: '0',
+							fee: '100000000',
+							senderPublicKey: '0fe9a3f1a21b5530f27f87a414b549e79a940bf24fdf2b2f05e7f22aeeecc86a',
+							asset: {
+								amount: '100',
+								data: 'send token',
+								recipientAddress: 'ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815',
+							},
+							signatures: [
+								'3cc8c8c81097fe59d9df356b3c3f1dd10f619bfabb54f5d187866092c67e0102c64dbe24f357df493cc7ebacdd2e55995db8912245b718d88ebf7f4f4ac01f04',
+							],
+						});
+					});
+			});
 		});
 	});
 });

--- a/test/commands/transaction/create.spec.ts
+++ b/test/commands/transaction/create.spec.ts
@@ -140,14 +140,15 @@ describe('transaction:create command', () => {
 						'--asset={"amount": "abc"}',
 						`--passphrase=${passphrase}`,
 						'--offline',
+						'--data-path=/tmp',
 						'--network=devnet',
 					])
 					.catch((error: Error) =>
 						expect(error.message).to.contain(
-							'Flag: --data-path must be specified while creating transaction offline',
+							'Flag: --data-path should not be specified while creating transaction offline',
 						),
 					)
-					.it('should throw error for missing data path flag.');
+					.it('should throw error for data path flag.');
 			});
 
 			describe(`transaction:create 2 0 100000000 --asset='{"amount": "abc"}' --passphrase=${passphrase} --offline`, () => {
@@ -160,7 +161,6 @@ describe('transaction:create command', () => {
 						'--asset={"amount": "abc"}',
 						`--passphrase=${passphrase}`,
 						'--offline',
-						'--data-path=/tmp',
 						'--network=devnet',
 					])
 					.catch((error: Error) =>
@@ -181,7 +181,6 @@ describe('transaction:create command', () => {
 						'--asset={"amount": "abc"}',
 						`--passphrase=${passphrase}`,
 						'--offline',
-						'--data-path=/tmp',
 						'--network=devnet',
 						'--network-identifier=873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3.',
 					])
@@ -203,7 +202,6 @@ describe('transaction:create command', () => {
 						`--asset=${transferAsset}`,
 						'--no-signature',
 						'--offline',
-						'--data-path=/tmp',
 						'--network-identifier=873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3.',
 						'--nonce=1',
 						'--network=devnet',
@@ -228,7 +226,6 @@ describe('transaction:create command', () => {
 						'--offline',
 						`--asset=${transferAsset}`,
 						`--passphrase=${passphrase}`,
-						'--data-path=/tmp',
 						'--network-identifier=873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3.',
 						'--nonce=1',
 						'--network=devnet',
@@ -253,7 +250,6 @@ describe('transaction:create command', () => {
 						`--asset=${transferAsset}`,
 						'--no-signature',
 						`--sender-publickey=${senderPublickey}`,
-						'--data-path=/tmp',
 						'--network-identifier=873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3.',
 						'--nonce=1',
 						'--network=devnet',
@@ -277,7 +273,6 @@ describe('transaction:create command', () => {
 						'--offline',
 						`--asset=${voteAsset}`,
 						`--passphrase=${passphrase}`,
-						'--data-path=/tmp',
 						'--network-identifier=873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3.',
 						'--nonce=1',
 						'--network=devnet',
@@ -301,7 +296,6 @@ describe('transaction:create command', () => {
 						'--offline',
 						`--asset=${unVoteAsset}`,
 						`--passphrase=${passphrase}`,
-						'--data-path=/tmp',
 						'--network-identifier=873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3.',
 						'--nonce=1',
 						'--network=devnet',
@@ -327,7 +321,6 @@ describe('transaction:create command', () => {
 						`--passphrase=${passphrase}`,
 						'--offline',
 						'--network=devnet',
-						'--data-path=/tmp',
 						'--network-identifier=873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3.',
 						'--nonce=1',
 					])
@@ -359,7 +352,6 @@ describe('transaction:create command', () => {
 						'100000000',
 						'--offline',
 						'--network=devnet',
-						'--data-path=/tmp',
 						'--network-identifier=873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3.',
 						'--nonce=1',
 					])
@@ -396,7 +388,6 @@ describe('transaction:create command', () => {
 						'--json',
 						'--offline',
 						'--network=devnet',
-						'--data-path=/tmp',
 						'--network-identifier=873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3.',
 						'--nonce=1',
 					])
@@ -433,7 +424,6 @@ describe('transaction:create command', () => {
 						'--json',
 						'--offline',
 						'--network=devnet',
-						'--data-path=/tmp',
 						'--network-identifier=873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3.',
 						'--nonce=1',
 					])

--- a/test/commands/transaction/sign.spec.ts
+++ b/test/commands/transaction/sign.spec.ts
@@ -153,7 +153,7 @@ describe('transaction:sign command', () => {
 
 	describe('offline', () => {
 		const unsignedTransaction =
-		'0802100018022080c2d72f2a200b211fce4b615083701cb8a8c99407e464b2f9aa4f367095322de1b77e5fcfbe322408641214ab0041a7d3f7b2c290b5b834d46bdc7b7eb858151a0a73656e6420746f6b656e';
+			'0802100018022080c2d72f2a200b211fce4b615083701cb8a8c99407e464b2f9aa4f367095322de1b77e5fcfbe322408641214ab0041a7d3f7b2c290b5b834d46bdc7b7eb858151a0a73656e6420746f6b656e';
 
 		describe('data path flag', () => {
 			setupTest()
@@ -164,7 +164,7 @@ describe('transaction:sign command', () => {
 					`--network-identifier=${networkIdentifierStr}`,
 					'--network=devnet',
 					'--offline',
-					'--data-path=/tmp'
+					'--data-path=/tmp',
 				])
 				.catch((error: Error) =>
 					expect(error.message).to.contain(

--- a/test/commands/transaction/sign.spec.ts
+++ b/test/commands/transaction/sign.spec.ts
@@ -23,6 +23,7 @@ import {
 	keysRegisterAssetSchema,
 	networkIdentifierStr,
 	dposVoteAssetSchema,
+	accountSchema,
 } from '../../utils/transactions';
 import * as appUtils from '../../../src/utils/application';
 import baseIPC from '../../../src/base_ipc';
@@ -72,30 +73,31 @@ const optionalKeys = [
 const signMultiSigCmdArgs = (unsignedTransaction: string, passphraseToSign: string): string[] => {
 	return [
 		'transaction:sign',
-		networkIdentifierStr,
 		unsignedTransaction,
 		`--passphrase=${passphraseToSign}`,
 		`--mandatory-keys=${mandatoryKeys[0]}`,
 		`--mandatory-keys=${mandatoryKeys[1]}`,
 		`--optional-keys=${optionalKeys[0]}`,
 		`--optional-keys=${optionalKeys[1]}`,
+		`--network-identifier=${networkIdentifierStr}`,
+		'--offline',
+		'--data-path=/tmp',
+		'--network=devnet',
+		'--sender-publickey=f1b9f4ee71b5d5857d3b346d441ca967f27870ebee88569db364fd13e28adba3',
 	];
 };
 
 const signMultiSigCmdArgsIncludingSender = (
 	unsignedTransaction: string,
 	passphrase: string,
-): string[] => [
-	...signMultiSigCmdArgs(unsignedTransaction, passphrase),
-	'--include-sender-signature',
-];
+): string[] => [...signMultiSigCmdArgs(unsignedTransaction, passphrase), '--include-sender'];
 
 const signMultiSigCmdArgsIncludingSenderJSON = (
 	unsignedTransaction: string,
 	passphrase: string,
 ): string[] => [
 	...signMultiSigCmdArgs(unsignedTransaction, passphrase),
-	'--include-sender-signature',
+	'--include-sender',
 	'--json',
 ];
 
@@ -110,10 +112,21 @@ describe('transaction:sign command', () => {
 	const ipcInvokeStub = sandbox.stub();
 	const ipcStartAndListenStub = sandbox.stub();
 
-	ipcInvokeStub.withArgs('app:getSchema').resolves({
-		transaction: transactionSchema,
-		transactionsAssets,
-	});
+	ipcInvokeStub
+		.withArgs('app:getSchema')
+		.resolves({
+			transaction: transactionSchema,
+			transactionsAssets,
+			account: accountSchema,
+		})
+		.withArgs('app:getNodeInfo')
+		.resolves({
+			networkIdentifier: networkIdentifierStr,
+		})
+		.withArgs('app:getAccount')
+		.resolves(
+			'0a1484f02a5e331d39e76c0e8255006ba796d879476e1206088082a991241a020802224608021220a4d4ee94c683f907ff7637abf5fde436856ad4f69dba11eecd45227d2d68f06c1a20eebd615e51dfdaa9c244c298a79d5266320bd73b2f56e9117ddb4a165d68d8502a0c0a0a0a001800200028003000',
+		);
 
 	afterEach(() => {
 		ipcInvokeStub.resetHistory();
@@ -135,168 +148,117 @@ describe('transaction:sign command', () => {
 	describe('Missing arguments', () => {
 		setupTest()
 			.command(['transaction:sign'])
-			.catch((error: Error) => expect(error.message).to.contain('Missing 2 required args:'))
-			.it('should throw an error when no arguments are provided.');
-
-		setupTest()
-			.command(['transaction:sign', networkIdentifierStr])
 			.catch((error: Error) => expect(error.message).to.contain('Missing 1 required arg:'))
 			.it('should throw an error when missing transaction argument.');
 	});
 
-	describe('sign transaction from single account', () => {
+	describe('offline', () => {
 		const unsignedTransaction =
-			'0802100018022080c2d72f2a200b211fce4b615083701cb8a8c99407e464b2f9aa4f367095322de1b77e5fcfbe322408641214ab0041a7d3f7b2c290b5b834d46bdc7b7eb858151a0a73656e6420746f6b656e';
-		setupTest()
-			.command([
-				'transaction:sign',
-				networkIdentifierStr,
-				unsignedTransaction,
-				`--passphrase=${senderPassphrase}`,
-			])
-			.it('should return signed transaction string in hex format', () => {
-				expect(printJSONStub).to.be.calledOnce;
-				expect(printJSONStub).to.be.calledWithExactly({
-					transaction:
-						'0802100018022080c2d72f2a200b211fce4b615083701cb8a8c99407e464b2f9aa4f367095322de1b77e5fcfbe322408641214ab0041a7d3f7b2c290b5b834d46bdc7b7eb858151a0a73656e6420746f6b656e3a407a1283e24e46ec5a0416d0b13a48fd2ca3bc1f6a4ea3ef83f97d54ebd0b3d45b025bf91c00b60c4cddade00be8a4da9088ab83be702b583e67265323a8391406',
-				});
-			});
+		'0802100018022080c2d72f2a200b211fce4b615083701cb8a8c99407e464b2f9aa4f367095322de1b77e5fcfbe322408641214ab0041a7d3f7b2c290b5b834d46bdc7b7eb858151a0a73656e6420746f6b656e';
 
-		setupTest()
-			.command([
-				'transaction:sign',
-				networkIdentifierStr,
-				unsignedTransaction,
-				`--passphrase=${senderPassphrase}`,
-				'--json',
-			])
-			.it('should return signed transaction in json format', () => {
-				expect(printJSONStub).to.be.calledOnce;
-				expect(printJSONStub).to.be.calledWithExactly({
-					moduleID: 2,
-					assetID: 0,
-					nonce: '2',
-					fee: '100000000',
-					senderPublicKey: '0b211fce4b615083701cb8a8c99407e464b2f9aa4f367095322de1b77e5fcfbe',
-					asset: {
-						amount: '100',
-						recipientAddress: 'ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815',
-						data: 'send token',
-					},
-					signatures: [
-						'7a1283e24e46ec5a0416d0b13a48fd2ca3bc1f6a4ea3ef83f97d54ebd0b3d45b025bf91c00b60c4cddade00be8a4da9088ab83be702b583e67265323a8391406',
-					],
-				});
-			});
-	});
-
-	describe('sign multi signature registration transaction', () => {
-		const unsignedTransaction =
-			'0804100018022080c2d72f2a200b211fce4b615083701cb8a8c99407e464b2f9aa4f367095322de1b77e5fcfbe328a0108041220f1b9f4ee71b5d5857d3b346d441ca967f27870ebee88569db364fd13e28adba312204a67646a446313db964c39370359845c52fce9225a3929770ef41448c258fd391a20fa406b6952d377f0278920e3eb8da919e4cf5c68b02eeba5d8b3334fdc0369b61a2057df5c3811961939f8dcfa858c6eaefebfaa4de942f7e703bf88127e0ee9cca4';
-		const sign1 =
-			'0804100018022080c2d72f2a200b211fce4b615083701cb8a8c99407e464b2f9aa4f367095322de1b77e5fcfbe328a0108041220f1b9f4ee71b5d5857d3b346d441ca967f27870ebee88569db364fd13e28adba312204a67646a446313db964c39370359845c52fce9225a3929770ef41448c258fd391a20fa406b6952d377f0278920e3eb8da919e4cf5c68b02eeba5d8b3334fdc0369b61a2057df5c3811961939f8dcfa858c6eaefebfaa4de942f7e703bf88127e0ee9cca43a405221970ee34cd778d78cee2a5233806aa42836aa62e2b76384d56fe8cf4cd4f6c02006af1ca0b1a1f9fd4566c1a442a81185c342e16b8fd4b95808b01a3523023a003a003a003a00';
-		const sign2 =
-			'0804100018022080c2d72f2a200b211fce4b615083701cb8a8c99407e464b2f9aa4f367095322de1b77e5fcfbe328a0108041220f1b9f4ee71b5d5857d3b346d441ca967f27870ebee88569db364fd13e28adba312204a67646a446313db964c39370359845c52fce9225a3929770ef41448c258fd391a20fa406b6952d377f0278920e3eb8da919e4cf5c68b02eeba5d8b3334fdc0369b61a2057df5c3811961939f8dcfa858c6eaefebfaa4de942f7e703bf88127e0ee9cca43a405221970ee34cd778d78cee2a5233806aa42836aa62e2b76384d56fe8cf4cd4f6c02006af1ca0b1a1f9fd4566c1a442a81185c342e16b8fd4b95808b01a3523023a003a40408061c9ea44ec5c2a2baad0301d15cf01035bcebb9e133738619685b7f0056be67d29596537d928b9288adbb12242d4f233647873e5d481d799c6b46099030f3a003a00';
-		const sign3 =
-			'0804100018022080c2d72f2a200b211fce4b615083701cb8a8c99407e464b2f9aa4f367095322de1b77e5fcfbe328a0108041220f1b9f4ee71b5d5857d3b346d441ca967f27870ebee88569db364fd13e28adba312204a67646a446313db964c39370359845c52fce9225a3929770ef41448c258fd391a20fa406b6952d377f0278920e3eb8da919e4cf5c68b02eeba5d8b3334fdc0369b61a2057df5c3811961939f8dcfa858c6eaefebfaa4de942f7e703bf88127e0ee9cca43a405221970ee34cd778d78cee2a5233806aa42836aa62e2b76384d56fe8cf4cd4f6c02006af1ca0b1a1f9fd4566c1a442a81185c342e16b8fd4b95808b01a3523023a406f067e0a7dc666a6604f45e843698b05c8c9872393d32d8b49f798608ef7e27d3869c630c309352a92b73af6822ddfa223b5fbf2ec74fd5860d632f88f6d790a3a40408061c9ea44ec5c2a2baad0301d15cf01035bcebb9e133738619685b7f0056be67d29596537d928b9288adbb12242d4f233647873e5d481d799c6b46099030f3a003a00';
-		const sign4 =
-			'0804100018022080c2d72f2a200b211fce4b615083701cb8a8c99407e464b2f9aa4f367095322de1b77e5fcfbe328a0108041220f1b9f4ee71b5d5857d3b346d441ca967f27870ebee88569db364fd13e28adba312204a67646a446313db964c39370359845c52fce9225a3929770ef41448c258fd391a20fa406b6952d377f0278920e3eb8da919e4cf5c68b02eeba5d8b3334fdc0369b61a2057df5c3811961939f8dcfa858c6eaefebfaa4de942f7e703bf88127e0ee9cca43a405221970ee34cd778d78cee2a5233806aa42836aa62e2b76384d56fe8cf4cd4f6c02006af1ca0b1a1f9fd4566c1a442a81185c342e16b8fd4b95808b01a3523023a406f067e0a7dc666a6604f45e843698b05c8c9872393d32d8b49f798608ef7e27d3869c630c309352a92b73af6822ddfa223b5fbf2ec74fd5860d632f88f6d790a3a40408061c9ea44ec5c2a2baad0301d15cf01035bcebb9e133738619685b7f0056be67d29596537d928b9288adbb12242d4f233647873e5d481d799c6b46099030f3a40d01ccfc1a9ec73c7d71ea716491c1e5290bad9ca47363fe7952377a3d6f3ebe1e2ca14b651b6497025a0ada6635db6d5519400c4f7ccb8586d8ee9310313a2043a00';
-		const signedTransaction =
-			'0804100018022080c2d72f2a200b211fce4b615083701cb8a8c99407e464b2f9aa4f367095322de1b77e5fcfbe328a0108041220f1b9f4ee71b5d5857d3b346d441ca967f27870ebee88569db364fd13e28adba312204a67646a446313db964c39370359845c52fce9225a3929770ef41448c258fd391a20fa406b6952d377f0278920e3eb8da919e4cf5c68b02eeba5d8b3334fdc0369b61a2057df5c3811961939f8dcfa858c6eaefebfaa4de942f7e703bf88127e0ee9cca43a405221970ee34cd778d78cee2a5233806aa42836aa62e2b76384d56fe8cf4cd4f6c02006af1ca0b1a1f9fd4566c1a442a81185c342e16b8fd4b95808b01a3523023a406f067e0a7dc666a6604f45e843698b05c8c9872393d32d8b49f798608ef7e27d3869c630c309352a92b73af6822ddfa223b5fbf2ec74fd5860d632f88f6d790a3a40408061c9ea44ec5c2a2baad0301d15cf01035bcebb9e133738619685b7f0056be67d29596537d928b9288adbb12242d4f233647873e5d481d799c6b46099030f3a40d01ccfc1a9ec73c7d71ea716491c1e5290bad9ca47363fe7952377a3d6f3ebe1e2ca14b651b6497025a0ada6635db6d5519400c4f7ccb8586d8ee9310313a2043a40c5b98e8496cb2562429bd83ae75ee287bcddaea64bab91e0b1c04ac4554819cc2b4262ef1987dbeef8403899bbc2610308c070878acabb02da404758b74a8b00';
-
-		setupTest()
-			.command(signMultiSigCmdArgsIncludingSender(unsignedTransaction, senderPassphrase))
-			.it('should return signed transaction for sender account', () => {
-				expect(printJSONStub).to.be.calledOnce;
-				expect(printJSONStub).to.be.calledWithExactly({
-					transaction: sign1,
-				});
-			});
-
-		setupTest()
-			.command(signMultiSigCmdArgsIncludingSender(sign1, mandatoryPassphrases[0]))
-			.it('should return signed transaction for mandatory account 1', () => {
-				expect(printJSONStub).to.be.calledOnce;
-				expect(printJSONStub).to.be.calledWithExactly({
-					transaction: sign2,
-				});
-			});
-
-		setupTest()
-			.command(signMultiSigCmdArgsIncludingSender(sign2, mandatoryPassphrases[1]))
-			.it('should return signed transaction for mandatory account 2', () => {
-				expect(printJSONStub).to.be.calledOnce;
-				expect(printJSONStub).to.be.calledWithExactly({
-					transaction: sign3,
-				});
-			});
-
-		setupTest()
-			.command(signMultiSigCmdArgsIncludingSender(sign3, optionalPassphrases[0]))
-			.it('should return signed transaction for optional account 1', () => {
-				expect(printJSONStub).to.be.calledOnce;
-				expect(printJSONStub).to.be.calledWithExactly({
-					transaction: sign4,
-				});
-			});
-
-		setupTest()
-			.command(signMultiSigCmdArgsIncludingSender(sign4, optionalPassphrases[1]))
-			.it('should return signed transaction for optional account 2', () => {
-				expect(printJSONStub).to.be.calledOnce;
-				expect(printJSONStub).to.be.calledWithExactly({
-					transaction: signedTransaction,
-				});
-			});
-
-		setupTest()
-			.command(signMultiSigCmdArgsIncludingSenderJSON(sign4, optionalPassphrases[1]))
-			.it('should return fully signed transaction string in hex format', () => {
-				expect(printJSONStub.callCount).to.equal(1);
-				expect(printJSONStub).to.be.calledWithExactly({
-					moduleID: 4,
-					assetID: 0,
-					nonce: '2',
-					fee: '100000000',
-					senderPublicKey: '0b211fce4b615083701cb8a8c99407e464b2f9aa4f367095322de1b77e5fcfbe',
-					asset: {
-						numberOfSignatures: 4,
-						mandatoryKeys: [
-							'f1b9f4ee71b5d5857d3b346d441ca967f27870ebee88569db364fd13e28adba3',
-							'4a67646a446313db964c39370359845c52fce9225a3929770ef41448c258fd39',
-						],
-						optionalKeys: [
-							'fa406b6952d377f0278920e3eb8da919e4cf5c68b02eeba5d8b3334fdc0369b6',
-							'57df5c3811961939f8dcfa858c6eaefebfaa4de942f7e703bf88127e0ee9cca4',
-						],
-					},
-					signatures: [
-						'5221970ee34cd778d78cee2a5233806aa42836aa62e2b76384d56fe8cf4cd4f6c02006af1ca0b1a1f9fd4566c1a442a81185c342e16b8fd4b95808b01a352302',
-						'6f067e0a7dc666a6604f45e843698b05c8c9872393d32d8b49f798608ef7e27d3869c630c309352a92b73af6822ddfa223b5fbf2ec74fd5860d632f88f6d790a',
-						'408061c9ea44ec5c2a2baad0301d15cf01035bcebb9e133738619685b7f0056be67d29596537d928b9288adbb12242d4f233647873e5d481d799c6b46099030f',
-						'd01ccfc1a9ec73c7d71ea716491c1e5290bad9ca47363fe7952377a3d6f3ebe1e2ca14b651b6497025a0ada6635db6d5519400c4f7ccb8586d8ee9310313a204',
-						'c5b98e8496cb2562429bd83ae75ee287bcddaea64bab91e0b1c04ac4554819cc2b4262ef1987dbeef8403899bbc2610308c070878acabb02da404758b74a8b00',
-					],
-				});
-			});
-	});
-
-	describe('sign transaction from multi-signature accounts', () => {
-		const unsignedTransaction =
-			'0802100018022080c2d72f2a20f1b9f4ee71b5d5857d3b346d441ca967f27870ebee88569db364fd13e28adba3322408641214ab0041a7d3f7b2c290b5b834d46bdc7b7eb858151a0a73656e6420746f6b656e';
-		const sign1 =
-			'0802100018022080c2d72f2a20f1b9f4ee71b5d5857d3b346d441ca967f27870ebee88569db364fd13e28adba3322408641214ab0041a7d3f7b2c290b5b834d46bdc7b7eb858151a0a73656e6420746f6b656e3a003a40f39a1d92a381490e9bed6b7105cbaf76849f8985258a7e84779fce8ecdda3fbec5bca5cb0df749731294d035677ebdb2c6664229eb11ec4c4e9a9a0b86a0010a3a003a00';
-		const sign2 =
-			'0802100018022080c2d72f2a20f1b9f4ee71b5d5857d3b346d441ca967f27870ebee88569db364fd13e28adba3322408641214ab0041a7d3f7b2c290b5b834d46bdc7b7eb858151a0a73656e6420746f6b656e3a401f11d2300ecabb85e5d8e2d51a227e566fdf6fe7750345deb6162fa13ce44fcfcf060a7f073912c2a940e9d0351a671537b213509f04c6a4e67572aa3850b1033a40f39a1d92a381490e9bed6b7105cbaf76849f8985258a7e84779fce8ecdda3fbec5bca5cb0df749731294d035677ebdb2c6664229eb11ec4c4e9a9a0b86a0010a3a003a00';
-		const sign3 =
-			'0802100018022080c2d72f2a20f1b9f4ee71b5d5857d3b346d441ca967f27870ebee88569db364fd13e28adba3322408641214ab0041a7d3f7b2c290b5b834d46bdc7b7eb858151a0a73656e6420746f6b656e3a401f11d2300ecabb85e5d8e2d51a227e566fdf6fe7750345deb6162fa13ce44fcfcf060a7f073912c2a940e9d0351a671537b213509f04c6a4e67572aa3850b1033a40f39a1d92a381490e9bed6b7105cbaf76849f8985258a7e84779fce8ecdda3fbec5bca5cb0df749731294d035677ebdb2c6664229eb11ec4c4e9a9a0b86a0010a3a40a40e56c0a6aaa549bd34c2b948aec20fecd3c60661da472fb0ffc3ce98766ddea1179138d5d110abaa97f057bedecdc5d2aa4617a328bedd415481bd9e87ef0e3a00';
-		const signedTransaction =
-			'0802100018022080c2d72f2a20f1b9f4ee71b5d5857d3b346d441ca967f27870ebee88569db364fd13e28adba3322408641214ab0041a7d3f7b2c290b5b834d46bdc7b7eb858151a0a73656e6420746f6b656e3a401f11d2300ecabb85e5d8e2d51a227e566fdf6fe7750345deb6162fa13ce44fcfcf060a7f073912c2a940e9d0351a671537b213509f04c6a4e67572aa3850b1033a40f39a1d92a381490e9bed6b7105cbaf76849f8985258a7e84779fce8ecdda3fbec5bca5cb0df749731294d035677ebdb2c6664229eb11ec4c4e9a9a0b86a0010a3a40a40e56c0a6aaa549bd34c2b948aec20fecd3c60661da472fb0ffc3ce98766ddea1179138d5d110abaa97f057bedecdc5d2aa4617a328bedd415481bd9e87ef0e3a4055e35fbc455dfd0c71455a3c4fb3b0363bd90810fae11d715a95e3892847afc4e3eb42c692e3d0da7c32e8a8225ddeca565eed9c821e24a57c74db196d87ed01';
-
-		describe('mandatory keys are specified', () => {
+		describe('missing data path flag', () => {
 			setupTest()
-				.command(signMultiSigCmdArgs(unsignedTransaction, mandatoryPassphrases[0]))
-				.it('should return signed transaction for mandatory account 1', () => {
+				.command([
+					'transaction:sign',
+					unsignedTransaction,
+					`--passphrase=${senderPassphrase}`,
+					`--network-identifier=${networkIdentifierStr}`,
+					'--network=devnet',
+					'--offline',
+				])
+				.catch((error: Error) =>
+					expect(error.message).to.contain(
+						'Flag: --data-path must be specified while signing offline.',
+					),
+				)
+				.it('should throw an error when missing data path flag.');
+		});
+
+		describe('missing network identifier flag', () => {
+			setupTest()
+				.command([
+					'transaction:sign',
+					unsignedTransaction,
+					`--passphrase=${senderPassphrase}`,
+					'--network=devnet',
+					'--data-path=/tmp',
+					'--offline',
+				])
+				.catch((error: Error) =>
+					expect(error.message).to.contain(
+						'Flag: --network-identifier must be specified while signing offline.',
+					),
+				)
+				.it('should throw an error when missing network identifier flag.');
+		});
+
+		describe('sign transaction from single account', () => {
+			setupTest()
+				.command([
+					'transaction:sign',
+					unsignedTransaction,
+					`--passphrase=${senderPassphrase}`,
+					`--network-identifier=${networkIdentifierStr}`,
+					'--offline',
+					'--data-path=/tmp',
+					'--network=devnet',
+				])
+				.it('should return signed transaction string in hex format', () => {
+					expect(printJSONStub).to.be.calledOnce;
+					expect(printJSONStub).to.be.calledWithExactly({
+						transaction:
+							'0802100018022080c2d72f2a200b211fce4b615083701cb8a8c99407e464b2f9aa4f367095322de1b77e5fcfbe322408641214ab0041a7d3f7b2c290b5b834d46bdc7b7eb858151a0a73656e6420746f6b656e3a407a1283e24e46ec5a0416d0b13a48fd2ca3bc1f6a4ea3ef83f97d54ebd0b3d45b025bf91c00b60c4cddade00be8a4da9088ab83be702b583e67265323a8391406',
+					});
+				});
+
+			setupTest()
+				.command([
+					'transaction:sign',
+					unsignedTransaction,
+					`--passphrase=${senderPassphrase}`,
+					`--network-identifier=${networkIdentifierStr}`,
+					'--json',
+					'--offline',
+					'--data-path=/tmp',
+					'--network=devnet',
+				])
+				.it('should return signed transaction in json format', () => {
+					expect(printJSONStub).to.be.calledOnce;
+					expect(printJSONStub).to.be.calledWithExactly({
+						moduleID: 2,
+						assetID: 0,
+						nonce: '2',
+						fee: '100000000',
+						senderPublicKey: '0b211fce4b615083701cb8a8c99407e464b2f9aa4f367095322de1b77e5fcfbe',
+						asset: {
+							amount: '100',
+							recipientAddress: 'ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815',
+							data: 'send token',
+						},
+						signatures: [
+							'7a1283e24e46ec5a0416d0b13a48fd2ca3bc1f6a4ea3ef83f97d54ebd0b3d45b025bf91c00b60c4cddade00be8a4da9088ab83be702b583e67265323a8391406',
+						],
+					});
+				});
+		});
+
+		describe('sign multi signature registration transaction', () => {
+			const unsignedMultiSigTransaction =
+				'0804100018022080c2d72f2a200b211fce4b615083701cb8a8c99407e464b2f9aa4f367095322de1b77e5fcfbe328a0108041220f1b9f4ee71b5d5857d3b346d441ca967f27870ebee88569db364fd13e28adba312204a67646a446313db964c39370359845c52fce9225a3929770ef41448c258fd391a20fa406b6952d377f0278920e3eb8da919e4cf5c68b02eeba5d8b3334fdc0369b61a2057df5c3811961939f8dcfa858c6eaefebfaa4de942f7e703bf88127e0ee9cca4';
+			const sign1 =
+				'0804100018022080c2d72f2a200b211fce4b615083701cb8a8c99407e464b2f9aa4f367095322de1b77e5fcfbe328a0108041220f1b9f4ee71b5d5857d3b346d441ca967f27870ebee88569db364fd13e28adba312204a67646a446313db964c39370359845c52fce9225a3929770ef41448c258fd391a20fa406b6952d377f0278920e3eb8da919e4cf5c68b02eeba5d8b3334fdc0369b61a2057df5c3811961939f8dcfa858c6eaefebfaa4de942f7e703bf88127e0ee9cca43a405221970ee34cd778d78cee2a5233806aa42836aa62e2b76384d56fe8cf4cd4f6c02006af1ca0b1a1f9fd4566c1a442a81185c342e16b8fd4b95808b01a3523023a003a003a003a00';
+			const sign2 =
+				'0804100018022080c2d72f2a200b211fce4b615083701cb8a8c99407e464b2f9aa4f367095322de1b77e5fcfbe328a0108041220f1b9f4ee71b5d5857d3b346d441ca967f27870ebee88569db364fd13e28adba312204a67646a446313db964c39370359845c52fce9225a3929770ef41448c258fd391a20fa406b6952d377f0278920e3eb8da919e4cf5c68b02eeba5d8b3334fdc0369b61a2057df5c3811961939f8dcfa858c6eaefebfaa4de942f7e703bf88127e0ee9cca43a405221970ee34cd778d78cee2a5233806aa42836aa62e2b76384d56fe8cf4cd4f6c02006af1ca0b1a1f9fd4566c1a442a81185c342e16b8fd4b95808b01a3523023a003a40408061c9ea44ec5c2a2baad0301d15cf01035bcebb9e133738619685b7f0056be67d29596537d928b9288adbb12242d4f233647873e5d481d799c6b46099030f3a003a00';
+			const sign3 =
+				'0804100018022080c2d72f2a200b211fce4b615083701cb8a8c99407e464b2f9aa4f367095322de1b77e5fcfbe328a0108041220f1b9f4ee71b5d5857d3b346d441ca967f27870ebee88569db364fd13e28adba312204a67646a446313db964c39370359845c52fce9225a3929770ef41448c258fd391a20fa406b6952d377f0278920e3eb8da919e4cf5c68b02eeba5d8b3334fdc0369b61a2057df5c3811961939f8dcfa858c6eaefebfaa4de942f7e703bf88127e0ee9cca43a405221970ee34cd778d78cee2a5233806aa42836aa62e2b76384d56fe8cf4cd4f6c02006af1ca0b1a1f9fd4566c1a442a81185c342e16b8fd4b95808b01a3523023a406f067e0a7dc666a6604f45e843698b05c8c9872393d32d8b49f798608ef7e27d3869c630c309352a92b73af6822ddfa223b5fbf2ec74fd5860d632f88f6d790a3a40408061c9ea44ec5c2a2baad0301d15cf01035bcebb9e133738619685b7f0056be67d29596537d928b9288adbb12242d4f233647873e5d481d799c6b46099030f3a003a00';
+			const sign4 =
+				'0804100018022080c2d72f2a200b211fce4b615083701cb8a8c99407e464b2f9aa4f367095322de1b77e5fcfbe328a0108041220f1b9f4ee71b5d5857d3b346d441ca967f27870ebee88569db364fd13e28adba312204a67646a446313db964c39370359845c52fce9225a3929770ef41448c258fd391a20fa406b6952d377f0278920e3eb8da919e4cf5c68b02eeba5d8b3334fdc0369b61a2057df5c3811961939f8dcfa858c6eaefebfaa4de942f7e703bf88127e0ee9cca43a405221970ee34cd778d78cee2a5233806aa42836aa62e2b76384d56fe8cf4cd4f6c02006af1ca0b1a1f9fd4566c1a442a81185c342e16b8fd4b95808b01a3523023a406f067e0a7dc666a6604f45e843698b05c8c9872393d32d8b49f798608ef7e27d3869c630c309352a92b73af6822ddfa223b5fbf2ec74fd5860d632f88f6d790a3a40408061c9ea44ec5c2a2baad0301d15cf01035bcebb9e133738619685b7f0056be67d29596537d928b9288adbb12242d4f233647873e5d481d799c6b46099030f3a40d01ccfc1a9ec73c7d71ea716491c1e5290bad9ca47363fe7952377a3d6f3ebe1e2ca14b651b6497025a0ada6635db6d5519400c4f7ccb8586d8ee9310313a2043a00';
+			const signedTransaction =
+				'0804100018022080c2d72f2a200b211fce4b615083701cb8a8c99407e464b2f9aa4f367095322de1b77e5fcfbe328a0108041220f1b9f4ee71b5d5857d3b346d441ca967f27870ebee88569db364fd13e28adba312204a67646a446313db964c39370359845c52fce9225a3929770ef41448c258fd391a20fa406b6952d377f0278920e3eb8da919e4cf5c68b02eeba5d8b3334fdc0369b61a2057df5c3811961939f8dcfa858c6eaefebfaa4de942f7e703bf88127e0ee9cca43a405221970ee34cd778d78cee2a5233806aa42836aa62e2b76384d56fe8cf4cd4f6c02006af1ca0b1a1f9fd4566c1a442a81185c342e16b8fd4b95808b01a3523023a406f067e0a7dc666a6604f45e843698b05c8c9872393d32d8b49f798608ef7e27d3869c630c309352a92b73af6822ddfa223b5fbf2ec74fd5860d632f88f6d790a3a40408061c9ea44ec5c2a2baad0301d15cf01035bcebb9e133738619685b7f0056be67d29596537d928b9288adbb12242d4f233647873e5d481d799c6b46099030f3a40d01ccfc1a9ec73c7d71ea716491c1e5290bad9ca47363fe7952377a3d6f3ebe1e2ca14b651b6497025a0ada6635db6d5519400c4f7ccb8586d8ee9310313a2043a40c5b98e8496cb2562429bd83ae75ee287bcddaea64bab91e0b1c04ac4554819cc2b4262ef1987dbeef8403899bbc2610308c070878acabb02da404758b74a8b00';
+
+			setupTest()
+				.command(signMultiSigCmdArgsIncludingSender(unsignedMultiSigTransaction, senderPassphrase))
+				.it('should return signed transaction for sender account', () => {
 					expect(printJSONStub).to.be.calledOnce;
 					expect(printJSONStub).to.be.calledWithExactly({
 						transaction: sign1,
@@ -304,19 +266,17 @@ describe('transaction:sign command', () => {
 				});
 
 			setupTest()
-				.command(signMultiSigCmdArgs(sign1, mandatoryPassphrases[1]))
-				.it('should return signed transaction for mandatory account 2', () => {
+				.command(signMultiSigCmdArgsIncludingSender(sign1, mandatoryPassphrases[0]))
+				.it('should return signed transaction for mandatory account 1', () => {
 					expect(printJSONStub).to.be.calledOnce;
 					expect(printJSONStub).to.be.calledWithExactly({
 						transaction: sign2,
 					});
 				});
-		});
 
-		describe('optional keys are specified', () => {
 			setupTest()
-				.command(signMultiSigCmdArgs(sign2, optionalPassphrases[0]))
-				.it('should return signed transaction for optional account 1', () => {
+				.command(signMultiSigCmdArgsIncludingSender(sign2, mandatoryPassphrases[1]))
+				.it('should return signed transaction for mandatory account 2', () => {
 					expect(printJSONStub).to.be.calledOnce;
 					expect(printJSONStub).to.be.calledWithExactly({
 						transaction: sign3,
@@ -324,7 +284,16 @@ describe('transaction:sign command', () => {
 				});
 
 			setupTest()
-				.command(signMultiSigCmdArgs(sign3, optionalPassphrases[1]))
+				.command(signMultiSigCmdArgsIncludingSender(sign3, optionalPassphrases[0]))
+				.it('should return signed transaction for optional account 1', () => {
+					expect(printJSONStub).to.be.calledOnce;
+					expect(printJSONStub).to.be.calledWithExactly({
+						transaction: sign4,
+					});
+				});
+
+			setupTest()
+				.command(signMultiSigCmdArgsIncludingSender(sign4, optionalPassphrases[1]))
 				.it('should return signed transaction for optional account 2', () => {
 					expect(printJSONStub).to.be.calledOnce;
 					expect(printJSONStub).to.be.calledWithExactly({
@@ -333,28 +302,322 @@ describe('transaction:sign command', () => {
 				});
 
 			setupTest()
-				.command(signMultiSigCmdArgsJSON(sign3, optionalPassphrases[1]))
+				.command(signMultiSigCmdArgsIncludingSenderJSON(sign4, optionalPassphrases[1]))
 				.it('should return fully signed transaction string in hex format', () => {
 					expect(printJSONStub.callCount).to.equal(1);
 					expect(printJSONStub).to.be.calledWithExactly({
-						asset: {
-							amount: '100',
-							data: 'send token',
-							recipientAddress: 'ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815',
-						},
+						moduleID: 4,
 						assetID: 0,
-						fee: '100000000',
-						moduleID: 2,
 						nonce: '2',
-						senderPublicKey: 'f1b9f4ee71b5d5857d3b346d441ca967f27870ebee88569db364fd13e28adba3',
+						fee: '100000000',
+						senderPublicKey: '0b211fce4b615083701cb8a8c99407e464b2f9aa4f367095322de1b77e5fcfbe',
+						asset: {
+							numberOfSignatures: 4,
+							mandatoryKeys: [
+								'f1b9f4ee71b5d5857d3b346d441ca967f27870ebee88569db364fd13e28adba3',
+								'4a67646a446313db964c39370359845c52fce9225a3929770ef41448c258fd39',
+							],
+							optionalKeys: [
+								'fa406b6952d377f0278920e3eb8da919e4cf5c68b02eeba5d8b3334fdc0369b6',
+								'57df5c3811961939f8dcfa858c6eaefebfaa4de942f7e703bf88127e0ee9cca4',
+							],
+						},
 						signatures: [
-							'1f11d2300ecabb85e5d8e2d51a227e566fdf6fe7750345deb6162fa13ce44fcfcf060a7f073912c2a940e9d0351a671537b213509f04c6a4e67572aa3850b103',
-							'f39a1d92a381490e9bed6b7105cbaf76849f8985258a7e84779fce8ecdda3fbec5bca5cb0df749731294d035677ebdb2c6664229eb11ec4c4e9a9a0b86a0010a',
-							'a40e56c0a6aaa549bd34c2b948aec20fecd3c60661da472fb0ffc3ce98766ddea1179138d5d110abaa97f057bedecdc5d2aa4617a328bedd415481bd9e87ef0e',
-							'55e35fbc455dfd0c71455a3c4fb3b0363bd90810fae11d715a95e3892847afc4e3eb42c692e3d0da7c32e8a8225ddeca565eed9c821e24a57c74db196d87ed01',
+							'5221970ee34cd778d78cee2a5233806aa42836aa62e2b76384d56fe8cf4cd4f6c02006af1ca0b1a1f9fd4566c1a442a81185c342e16b8fd4b95808b01a352302',
+							'6f067e0a7dc666a6604f45e843698b05c8c9872393d32d8b49f798608ef7e27d3869c630c309352a92b73af6822ddfa223b5fbf2ec74fd5860d632f88f6d790a',
+							'408061c9ea44ec5c2a2baad0301d15cf01035bcebb9e133738619685b7f0056be67d29596537d928b9288adbb12242d4f233647873e5d481d799c6b46099030f',
+							'd01ccfc1a9ec73c7d71ea716491c1e5290bad9ca47363fe7952377a3d6f3ebe1e2ca14b651b6497025a0ada6635db6d5519400c4f7ccb8586d8ee9310313a204',
+							'c5b98e8496cb2562429bd83ae75ee287bcddaea64bab91e0b1c04ac4554819cc2b4262ef1987dbeef8403899bbc2610308c070878acabb02da404758b74a8b00',
 						],
 					});
 				});
+		});
+
+		describe('sign transaction from multi-signature accounts', () => {
+			const unsignedMultiSigTransaction =
+				'0802100018022080c2d72f2a20f1b9f4ee71b5d5857d3b346d441ca967f27870ebee88569db364fd13e28adba3322408641214ab0041a7d3f7b2c290b5b834d46bdc7b7eb858151a0a73656e6420746f6b656e';
+			const sign1 =
+				'0802100018022080c2d72f2a20f1b9f4ee71b5d5857d3b346d441ca967f27870ebee88569db364fd13e28adba3322408641214ab0041a7d3f7b2c290b5b834d46bdc7b7eb858151a0a73656e6420746f6b656e3a003a40f39a1d92a381490e9bed6b7105cbaf76849f8985258a7e84779fce8ecdda3fbec5bca5cb0df749731294d035677ebdb2c6664229eb11ec4c4e9a9a0b86a0010a3a003a00';
+			const sign2 =
+				'0802100018022080c2d72f2a20f1b9f4ee71b5d5857d3b346d441ca967f27870ebee88569db364fd13e28adba3322408641214ab0041a7d3f7b2c290b5b834d46bdc7b7eb858151a0a73656e6420746f6b656e3a401f11d2300ecabb85e5d8e2d51a227e566fdf6fe7750345deb6162fa13ce44fcfcf060a7f073912c2a940e9d0351a671537b213509f04c6a4e67572aa3850b1033a40f39a1d92a381490e9bed6b7105cbaf76849f8985258a7e84779fce8ecdda3fbec5bca5cb0df749731294d035677ebdb2c6664229eb11ec4c4e9a9a0b86a0010a3a003a00';
+			const sign3 =
+				'0802100018022080c2d72f2a20f1b9f4ee71b5d5857d3b346d441ca967f27870ebee88569db364fd13e28adba3322408641214ab0041a7d3f7b2c290b5b834d46bdc7b7eb858151a0a73656e6420746f6b656e3a401f11d2300ecabb85e5d8e2d51a227e566fdf6fe7750345deb6162fa13ce44fcfcf060a7f073912c2a940e9d0351a671537b213509f04c6a4e67572aa3850b1033a40f39a1d92a381490e9bed6b7105cbaf76849f8985258a7e84779fce8ecdda3fbec5bca5cb0df749731294d035677ebdb2c6664229eb11ec4c4e9a9a0b86a0010a3a40a40e56c0a6aaa549bd34c2b948aec20fecd3c60661da472fb0ffc3ce98766ddea1179138d5d110abaa97f057bedecdc5d2aa4617a328bedd415481bd9e87ef0e3a00';
+			const signedTransaction =
+				'0802100018022080c2d72f2a20f1b9f4ee71b5d5857d3b346d441ca967f27870ebee88569db364fd13e28adba3322408641214ab0041a7d3f7b2c290b5b834d46bdc7b7eb858151a0a73656e6420746f6b656e3a401f11d2300ecabb85e5d8e2d51a227e566fdf6fe7750345deb6162fa13ce44fcfcf060a7f073912c2a940e9d0351a671537b213509f04c6a4e67572aa3850b1033a40f39a1d92a381490e9bed6b7105cbaf76849f8985258a7e84779fce8ecdda3fbec5bca5cb0df749731294d035677ebdb2c6664229eb11ec4c4e9a9a0b86a0010a3a40a40e56c0a6aaa549bd34c2b948aec20fecd3c60661da472fb0ffc3ce98766ddea1179138d5d110abaa97f057bedecdc5d2aa4617a328bedd415481bd9e87ef0e3a4055e35fbc455dfd0c71455a3c4fb3b0363bd90810fae11d715a95e3892847afc4e3eb42c692e3d0da7c32e8a8225ddeca565eed9c821e24a57c74db196d87ed01';
+
+			describe('mandatory keys are specified', () => {
+				setupTest()
+					.command(signMultiSigCmdArgs(unsignedMultiSigTransaction, mandatoryPassphrases[0]))
+					.it('should return signed transaction for mandatory account 1', () => {
+						expect(printJSONStub).to.be.calledOnce;
+						expect(printJSONStub).to.be.calledWithExactly({
+							transaction: sign1,
+						});
+					});
+
+				setupTest()
+					.command(signMultiSigCmdArgs(sign1, mandatoryPassphrases[1]))
+					.it('should return signed transaction for mandatory account 2', () => {
+						expect(printJSONStub).to.be.calledOnce;
+						expect(printJSONStub).to.be.calledWithExactly({
+							transaction: sign2,
+						});
+					});
+			});
+
+			describe('optional keys are specified', () => {
+				setupTest()
+					.command(signMultiSigCmdArgs(sign2, optionalPassphrases[0]))
+					.it('should return signed transaction for optional account 1', () => {
+						expect(printJSONStub).to.be.calledOnce;
+						expect(printJSONStub).to.be.calledWithExactly({
+							transaction: sign3,
+						});
+					});
+
+				setupTest()
+					.command(signMultiSigCmdArgs(sign3, optionalPassphrases[1]))
+					.it('should return signed transaction for optional account 2', () => {
+						expect(printJSONStub).to.be.calledOnce;
+						expect(printJSONStub).to.be.calledWithExactly({
+							transaction: signedTransaction,
+						});
+					});
+
+				setupTest()
+					.command(signMultiSigCmdArgsJSON(sign3, optionalPassphrases[1]))
+					.it('should return fully signed transaction string in hex format', () => {
+						expect(printJSONStub.callCount).to.equal(1);
+						expect(printJSONStub).to.be.calledWithExactly({
+							asset: {
+								amount: '100',
+								data: 'send token',
+								recipientAddress: 'ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815',
+							},
+							assetID: 0,
+							fee: '100000000',
+							moduleID: 2,
+							nonce: '2',
+							senderPublicKey: 'f1b9f4ee71b5d5857d3b346d441ca967f27870ebee88569db364fd13e28adba3',
+							signatures: [
+								'1f11d2300ecabb85e5d8e2d51a227e566fdf6fe7750345deb6162fa13ce44fcfcf060a7f073912c2a940e9d0351a671537b213509f04c6a4e67572aa3850b103',
+								'f39a1d92a381490e9bed6b7105cbaf76849f8985258a7e84779fce8ecdda3fbec5bca5cb0df749731294d035677ebdb2c6664229eb11ec4c4e9a9a0b86a0010a',
+								'a40e56c0a6aaa549bd34c2b948aec20fecd3c60661da472fb0ffc3ce98766ddea1179138d5d110abaa97f057bedecdc5d2aa4617a328bedd415481bd9e87ef0e',
+								'55e35fbc455dfd0c71455a3c4fb3b0363bd90810fae11d715a95e3892847afc4e3eb42c692e3d0da7c32e8a8225ddeca565eed9c821e24a57c74db196d87ed01',
+							],
+						});
+					});
+			});
+		});
+	});
+
+	describe('online', () => {
+		describe('sign transaction from single account', () => {
+			const unsignedTransaction =
+				'0802100018022080c2d72f2a200b211fce4b615083701cb8a8c99407e464b2f9aa4f367095322de1b77e5fcfbe322408641214ab0041a7d3f7b2c290b5b834d46bdc7b7eb858151a0a73656e6420746f6b656e';
+			setupTest()
+				.command(['transaction:sign', unsignedTransaction, `--passphrase=${senderPassphrase}`])
+				.it('should return signed transaction string in hex format', () => {
+					expect(printJSONStub).to.be.calledOnce;
+					expect(printJSONStub).to.be.calledWithExactly({
+						transaction:
+							'0802100018022080c2d72f2a200b211fce4b615083701cb8a8c99407e464b2f9aa4f367095322de1b77e5fcfbe322408641214ab0041a7d3f7b2c290b5b834d46bdc7b7eb858151a0a73656e6420746f6b656e3a407a1283e24e46ec5a0416d0b13a48fd2ca3bc1f6a4ea3ef83f97d54ebd0b3d45b025bf91c00b60c4cddade00be8a4da9088ab83be702b583e67265323a8391406',
+					});
+				});
+
+			setupTest()
+				.command([
+					'transaction:sign',
+					unsignedTransaction,
+					`--passphrase=${senderPassphrase}`,
+					'--json',
+				])
+				.it('should return signed transaction in json format', () => {
+					expect(printJSONStub).to.be.calledOnce;
+					expect(printJSONStub).to.be.calledWithExactly({
+						moduleID: 2,
+						assetID: 0,
+						nonce: '2',
+						fee: '100000000',
+						senderPublicKey: '0b211fce4b615083701cb8a8c99407e464b2f9aa4f367095322de1b77e5fcfbe',
+						asset: {
+							amount: '100',
+							recipientAddress: 'ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815',
+							data: 'send token',
+						},
+						signatures: [
+							'7a1283e24e46ec5a0416d0b13a48fd2ca3bc1f6a4ea3ef83f97d54ebd0b3d45b025bf91c00b60c4cddade00be8a4da9088ab83be702b583e67265323a8391406',
+						],
+					});
+				});
+		});
+
+		describe('sign multi signature registration transaction', () => {
+			const unsignedTransaction =
+				'0804100018022080c2d72f2a200b211fce4b615083701cb8a8c99407e464b2f9aa4f367095322de1b77e5fcfbe328a0108041220f1b9f4ee71b5d5857d3b346d441ca967f27870ebee88569db364fd13e28adba312204a67646a446313db964c39370359845c52fce9225a3929770ef41448c258fd391a20fa406b6952d377f0278920e3eb8da919e4cf5c68b02eeba5d8b3334fdc0369b61a2057df5c3811961939f8dcfa858c6eaefebfaa4de942f7e703bf88127e0ee9cca4';
+			const sign1 =
+				'0804100018022080c2d72f2a200b211fce4b615083701cb8a8c99407e464b2f9aa4f367095322de1b77e5fcfbe328a0108041220f1b9f4ee71b5d5857d3b346d441ca967f27870ebee88569db364fd13e28adba312204a67646a446313db964c39370359845c52fce9225a3929770ef41448c258fd391a20fa406b6952d377f0278920e3eb8da919e4cf5c68b02eeba5d8b3334fdc0369b61a2057df5c3811961939f8dcfa858c6eaefebfaa4de942f7e703bf88127e0ee9cca43a405221970ee34cd778d78cee2a5233806aa42836aa62e2b76384d56fe8cf4cd4f6c02006af1ca0b1a1f9fd4566c1a442a81185c342e16b8fd4b95808b01a3523023a003a003a003a00';
+			const sign2 =
+				'0804100018022080c2d72f2a200b211fce4b615083701cb8a8c99407e464b2f9aa4f367095322de1b77e5fcfbe328a0108041220f1b9f4ee71b5d5857d3b346d441ca967f27870ebee88569db364fd13e28adba312204a67646a446313db964c39370359845c52fce9225a3929770ef41448c258fd391a20fa406b6952d377f0278920e3eb8da919e4cf5c68b02eeba5d8b3334fdc0369b61a2057df5c3811961939f8dcfa858c6eaefebfaa4de942f7e703bf88127e0ee9cca43a405221970ee34cd778d78cee2a5233806aa42836aa62e2b76384d56fe8cf4cd4f6c02006af1ca0b1a1f9fd4566c1a442a81185c342e16b8fd4b95808b01a3523023a003a40408061c9ea44ec5c2a2baad0301d15cf01035bcebb9e133738619685b7f0056be67d29596537d928b9288adbb12242d4f233647873e5d481d799c6b46099030f3a003a00';
+			const sign3 =
+				'0804100018022080c2d72f2a200b211fce4b615083701cb8a8c99407e464b2f9aa4f367095322de1b77e5fcfbe328a0108041220f1b9f4ee71b5d5857d3b346d441ca967f27870ebee88569db364fd13e28adba312204a67646a446313db964c39370359845c52fce9225a3929770ef41448c258fd391a20fa406b6952d377f0278920e3eb8da919e4cf5c68b02eeba5d8b3334fdc0369b61a2057df5c3811961939f8dcfa858c6eaefebfaa4de942f7e703bf88127e0ee9cca43a405221970ee34cd778d78cee2a5233806aa42836aa62e2b76384d56fe8cf4cd4f6c02006af1ca0b1a1f9fd4566c1a442a81185c342e16b8fd4b95808b01a3523023a406f067e0a7dc666a6604f45e843698b05c8c9872393d32d8b49f798608ef7e27d3869c630c309352a92b73af6822ddfa223b5fbf2ec74fd5860d632f88f6d790a3a40408061c9ea44ec5c2a2baad0301d15cf01035bcebb9e133738619685b7f0056be67d29596537d928b9288adbb12242d4f233647873e5d481d799c6b46099030f3a003a00';
+			const sign4 =
+				'0804100018022080c2d72f2a200b211fce4b615083701cb8a8c99407e464b2f9aa4f367095322de1b77e5fcfbe328a0108041220f1b9f4ee71b5d5857d3b346d441ca967f27870ebee88569db364fd13e28adba312204a67646a446313db964c39370359845c52fce9225a3929770ef41448c258fd391a20fa406b6952d377f0278920e3eb8da919e4cf5c68b02eeba5d8b3334fdc0369b61a2057df5c3811961939f8dcfa858c6eaefebfaa4de942f7e703bf88127e0ee9cca43a405221970ee34cd778d78cee2a5233806aa42836aa62e2b76384d56fe8cf4cd4f6c02006af1ca0b1a1f9fd4566c1a442a81185c342e16b8fd4b95808b01a3523023a406f067e0a7dc666a6604f45e843698b05c8c9872393d32d8b49f798608ef7e27d3869c630c309352a92b73af6822ddfa223b5fbf2ec74fd5860d632f88f6d790a3a40408061c9ea44ec5c2a2baad0301d15cf01035bcebb9e133738619685b7f0056be67d29596537d928b9288adbb12242d4f233647873e5d481d799c6b46099030f3a40d01ccfc1a9ec73c7d71ea716491c1e5290bad9ca47363fe7952377a3d6f3ebe1e2ca14b651b6497025a0ada6635db6d5519400c4f7ccb8586d8ee9310313a2043a00';
+			const signedTransaction =
+				'0804100018022080c2d72f2a200b211fce4b615083701cb8a8c99407e464b2f9aa4f367095322de1b77e5fcfbe328a0108041220f1b9f4ee71b5d5857d3b346d441ca967f27870ebee88569db364fd13e28adba312204a67646a446313db964c39370359845c52fce9225a3929770ef41448c258fd391a20fa406b6952d377f0278920e3eb8da919e4cf5c68b02eeba5d8b3334fdc0369b61a2057df5c3811961939f8dcfa858c6eaefebfaa4de942f7e703bf88127e0ee9cca43a405221970ee34cd778d78cee2a5233806aa42836aa62e2b76384d56fe8cf4cd4f6c02006af1ca0b1a1f9fd4566c1a442a81185c342e16b8fd4b95808b01a3523023a406f067e0a7dc666a6604f45e843698b05c8c9872393d32d8b49f798608ef7e27d3869c630c309352a92b73af6822ddfa223b5fbf2ec74fd5860d632f88f6d790a3a40408061c9ea44ec5c2a2baad0301d15cf01035bcebb9e133738619685b7f0056be67d29596537d928b9288adbb12242d4f233647873e5d481d799c6b46099030f3a40d01ccfc1a9ec73c7d71ea716491c1e5290bad9ca47363fe7952377a3d6f3ebe1e2ca14b651b6497025a0ada6635db6d5519400c4f7ccb8586d8ee9310313a2043a40c5b98e8496cb2562429bd83ae75ee287bcddaea64bab91e0b1c04ac4554819cc2b4262ef1987dbeef8403899bbc2610308c070878acabb02da404758b74a8b00';
+
+			setupTest()
+				.command(signMultiSigCmdArgsIncludingSender(unsignedTransaction, senderPassphrase))
+				.it('should return signed transaction for sender account', () => {
+					expect(printJSONStub).to.be.calledOnce;
+					expect(printJSONStub).to.be.calledWithExactly({
+						transaction: sign1,
+					});
+				});
+
+			setupTest()
+				.command(signMultiSigCmdArgsIncludingSender(sign1, mandatoryPassphrases[0]))
+				.it('should return signed transaction for mandatory account 1', () => {
+					expect(printJSONStub).to.be.calledOnce;
+					expect(printJSONStub).to.be.calledWithExactly({
+						transaction: sign2,
+					});
+				});
+
+			setupTest()
+				.command(signMultiSigCmdArgsIncludingSender(sign2, mandatoryPassphrases[1]))
+				.it('should return signed transaction for mandatory account 2', () => {
+					expect(printJSONStub).to.be.calledOnce;
+					expect(printJSONStub).to.be.calledWithExactly({
+						transaction: sign3,
+					});
+				});
+
+			setupTest()
+				.command(signMultiSigCmdArgsIncludingSender(sign3, optionalPassphrases[0]))
+				.it('should return signed transaction for optional account 1', () => {
+					expect(printJSONStub).to.be.calledOnce;
+					expect(printJSONStub).to.be.calledWithExactly({
+						transaction: sign4,
+					});
+				});
+
+			setupTest()
+				.command(signMultiSigCmdArgsIncludingSender(sign4, optionalPassphrases[1]))
+				.it('should return signed transaction for optional account 2', () => {
+					expect(printJSONStub).to.be.calledOnce;
+					expect(printJSONStub).to.be.calledWithExactly({
+						transaction: signedTransaction,
+					});
+				});
+
+			setupTest()
+				.command(signMultiSigCmdArgsIncludingSenderJSON(sign4, optionalPassphrases[1]))
+				.it('should return fully signed transaction string in hex format', () => {
+					expect(printJSONStub.callCount).to.equal(1);
+					expect(printJSONStub).to.be.calledWithExactly({
+						moduleID: 4,
+						assetID: 0,
+						nonce: '2',
+						fee: '100000000',
+						senderPublicKey: '0b211fce4b615083701cb8a8c99407e464b2f9aa4f367095322de1b77e5fcfbe',
+						asset: {
+							numberOfSignatures: 4,
+							mandatoryKeys: [
+								'f1b9f4ee71b5d5857d3b346d441ca967f27870ebee88569db364fd13e28adba3',
+								'4a67646a446313db964c39370359845c52fce9225a3929770ef41448c258fd39',
+							],
+							optionalKeys: [
+								'fa406b6952d377f0278920e3eb8da919e4cf5c68b02eeba5d8b3334fdc0369b6',
+								'57df5c3811961939f8dcfa858c6eaefebfaa4de942f7e703bf88127e0ee9cca4',
+							],
+						},
+						signatures: [
+							'5221970ee34cd778d78cee2a5233806aa42836aa62e2b76384d56fe8cf4cd4f6c02006af1ca0b1a1f9fd4566c1a442a81185c342e16b8fd4b95808b01a352302',
+							'6f067e0a7dc666a6604f45e843698b05c8c9872393d32d8b49f798608ef7e27d3869c630c309352a92b73af6822ddfa223b5fbf2ec74fd5860d632f88f6d790a',
+							'408061c9ea44ec5c2a2baad0301d15cf01035bcebb9e133738619685b7f0056be67d29596537d928b9288adbb12242d4f233647873e5d481d799c6b46099030f',
+							'd01ccfc1a9ec73c7d71ea716491c1e5290bad9ca47363fe7952377a3d6f3ebe1e2ca14b651b6497025a0ada6635db6d5519400c4f7ccb8586d8ee9310313a204',
+							'c5b98e8496cb2562429bd83ae75ee287bcddaea64bab91e0b1c04ac4554819cc2b4262ef1987dbeef8403899bbc2610308c070878acabb02da404758b74a8b00',
+						],
+					});
+				});
+		});
+
+		describe('sign transaction from multi-signature accounts', () => {
+			const unsignedTransaction =
+				'0802100018022080c2d72f2a20f1b9f4ee71b5d5857d3b346d441ca967f27870ebee88569db364fd13e28adba3322408641214ab0041a7d3f7b2c290b5b834d46bdc7b7eb858151a0a73656e6420746f6b656e';
+			const sign1 =
+				'0802100018022080c2d72f2a20f1b9f4ee71b5d5857d3b346d441ca967f27870ebee88569db364fd13e28adba3322408641214ab0041a7d3f7b2c290b5b834d46bdc7b7eb858151a0a73656e6420746f6b656e3a003a40f39a1d92a381490e9bed6b7105cbaf76849f8985258a7e84779fce8ecdda3fbec5bca5cb0df749731294d035677ebdb2c6664229eb11ec4c4e9a9a0b86a0010a3a003a00';
+			const sign2 =
+				'0802100018022080c2d72f2a20f1b9f4ee71b5d5857d3b346d441ca967f27870ebee88569db364fd13e28adba3322408641214ab0041a7d3f7b2c290b5b834d46bdc7b7eb858151a0a73656e6420746f6b656e3a401f11d2300ecabb85e5d8e2d51a227e566fdf6fe7750345deb6162fa13ce44fcfcf060a7f073912c2a940e9d0351a671537b213509f04c6a4e67572aa3850b1033a40f39a1d92a381490e9bed6b7105cbaf76849f8985258a7e84779fce8ecdda3fbec5bca5cb0df749731294d035677ebdb2c6664229eb11ec4c4e9a9a0b86a0010a3a003a00';
+			const sign3 =
+				'0802100018022080c2d72f2a20f1b9f4ee71b5d5857d3b346d441ca967f27870ebee88569db364fd13e28adba3322408641214ab0041a7d3f7b2c290b5b834d46bdc7b7eb858151a0a73656e6420746f6b656e3a401f11d2300ecabb85e5d8e2d51a227e566fdf6fe7750345deb6162fa13ce44fcfcf060a7f073912c2a940e9d0351a671537b213509f04c6a4e67572aa3850b1033a40f39a1d92a381490e9bed6b7105cbaf76849f8985258a7e84779fce8ecdda3fbec5bca5cb0df749731294d035677ebdb2c6664229eb11ec4c4e9a9a0b86a0010a3a40a40e56c0a6aaa549bd34c2b948aec20fecd3c60661da472fb0ffc3ce98766ddea1179138d5d110abaa97f057bedecdc5d2aa4617a328bedd415481bd9e87ef0e3a00';
+			const signedTransaction =
+				'0802100018022080c2d72f2a20f1b9f4ee71b5d5857d3b346d441ca967f27870ebee88569db364fd13e28adba3322408641214ab0041a7d3f7b2c290b5b834d46bdc7b7eb858151a0a73656e6420746f6b656e3a401f11d2300ecabb85e5d8e2d51a227e566fdf6fe7750345deb6162fa13ce44fcfcf060a7f073912c2a940e9d0351a671537b213509f04c6a4e67572aa3850b1033a40f39a1d92a381490e9bed6b7105cbaf76849f8985258a7e84779fce8ecdda3fbec5bca5cb0df749731294d035677ebdb2c6664229eb11ec4c4e9a9a0b86a0010a3a40a40e56c0a6aaa549bd34c2b948aec20fecd3c60661da472fb0ffc3ce98766ddea1179138d5d110abaa97f057bedecdc5d2aa4617a328bedd415481bd9e87ef0e3a4055e35fbc455dfd0c71455a3c4fb3b0363bd90810fae11d715a95e3892847afc4e3eb42c692e3d0da7c32e8a8225ddeca565eed9c821e24a57c74db196d87ed01';
+
+			describe('mandatory keys are specified', () => {
+				setupTest()
+					.command(signMultiSigCmdArgs(unsignedTransaction, mandatoryPassphrases[0]))
+					.it('should return signed transaction for mandatory account 1', () => {
+						expect(printJSONStub).to.be.calledOnce;
+						expect(printJSONStub).to.be.calledWithExactly({
+							transaction: sign1,
+						});
+					});
+
+				setupTest()
+					.command(signMultiSigCmdArgs(sign1, mandatoryPassphrases[1]))
+					.it('should return signed transaction for mandatory account 2', () => {
+						expect(printJSONStub).to.be.calledOnce;
+						expect(printJSONStub).to.be.calledWithExactly({
+							transaction: sign2,
+						});
+					});
+			});
+
+			describe('optional keys are specified', () => {
+				setupTest()
+					.command(signMultiSigCmdArgs(sign2, optionalPassphrases[0]))
+					.it('should return signed transaction for optional account 1', () => {
+						expect(printJSONStub).to.be.calledOnce;
+						expect(printJSONStub).to.be.calledWithExactly({
+							transaction: sign3,
+						});
+					});
+
+				setupTest()
+					.command(signMultiSigCmdArgs(sign3, optionalPassphrases[1]))
+					.it('should return signed transaction for optional account 2', () => {
+						expect(printJSONStub).to.be.calledOnce;
+						expect(printJSONStub).to.be.calledWithExactly({
+							transaction: signedTransaction,
+						});
+					});
+
+				setupTest()
+					.command(signMultiSigCmdArgsJSON(sign3, optionalPassphrases[1]))
+					.it('should return fully signed transaction string in hex format', () => {
+						expect(printJSONStub.callCount).to.equal(1);
+						expect(printJSONStub).to.be.calledWithExactly({
+							asset: {
+								amount: '100',
+								data: 'send token',
+								recipientAddress: 'ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815',
+							},
+							assetID: 0,
+							fee: '100000000',
+							moduleID: 2,
+							nonce: '2',
+							senderPublicKey: 'f1b9f4ee71b5d5857d3b346d441ca967f27870ebee88569db364fd13e28adba3',
+							signatures: [
+								'1f11d2300ecabb85e5d8e2d51a227e566fdf6fe7750345deb6162fa13ce44fcfcf060a7f073912c2a940e9d0351a671537b213509f04c6a4e67572aa3850b103',
+								'f39a1d92a381490e9bed6b7105cbaf76849f8985258a7e84779fce8ecdda3fbec5bca5cb0df749731294d035677ebdb2c6664229eb11ec4c4e9a9a0b86a0010a',
+								'a40e56c0a6aaa549bd34c2b948aec20fecd3c60661da472fb0ffc3ce98766ddea1179138d5d110abaa97f057bedecdc5d2aa4617a328bedd415481bd9e87ef0e',
+								'55e35fbc455dfd0c71455a3c4fb3b0363bd90810fae11d715a95e3892847afc4e3eb42c692e3d0da7c32e8a8225ddeca565eed9c821e24a57c74db196d87ed01',
+							],
+						});
+					});
+			});
 		});
 	});
 });

--- a/test/commands/transaction/sign.spec.ts
+++ b/test/commands/transaction/sign.spec.ts
@@ -81,7 +81,6 @@ const signMultiSigCmdArgs = (unsignedTransaction: string, passphraseToSign: stri
 		`--optional-keys=${optionalKeys[1]}`,
 		`--network-identifier=${networkIdentifierStr}`,
 		'--offline',
-		'--data-path=/tmp',
 		'--network=devnet',
 		'--sender-publickey=f1b9f4ee71b5d5857d3b346d441ca967f27870ebee88569db364fd13e28adba3',
 	];
@@ -156,7 +155,7 @@ describe('transaction:sign command', () => {
 		const unsignedTransaction =
 		'0802100018022080c2d72f2a200b211fce4b615083701cb8a8c99407e464b2f9aa4f367095322de1b77e5fcfbe322408641214ab0041a7d3f7b2c290b5b834d46bdc7b7eb858151a0a73656e6420746f6b656e';
 
-		describe('missing data path flag', () => {
+		describe('data path flag', () => {
 			setupTest()
 				.command([
 					'transaction:sign',
@@ -165,13 +164,14 @@ describe('transaction:sign command', () => {
 					`--network-identifier=${networkIdentifierStr}`,
 					'--network=devnet',
 					'--offline',
+					'--data-path=/tmp'
 				])
 				.catch((error: Error) =>
 					expect(error.message).to.contain(
-						'Flag: --data-path must be specified while signing offline.',
+						'Flag: --data-path should not be specified while signing offline.',
 					),
 				)
-				.it('should throw an error when missing data path flag.');
+				.it('should throw an error when data path flag specified.');
 		});
 
 		describe('missing network identifier flag', () => {
@@ -181,7 +181,7 @@ describe('transaction:sign command', () => {
 					unsignedTransaction,
 					`--passphrase=${senderPassphrase}`,
 					'--network=devnet',
-					'--data-path=/tmp',
+
 					'--offline',
 				])
 				.catch((error: Error) =>
@@ -200,7 +200,7 @@ describe('transaction:sign command', () => {
 					`--passphrase=${senderPassphrase}`,
 					`--network-identifier=${networkIdentifierStr}`,
 					'--offline',
-					'--data-path=/tmp',
+
 					'--network=devnet',
 				])
 				.it('should return signed transaction string in hex format', () => {
@@ -219,7 +219,7 @@ describe('transaction:sign command', () => {
 					`--network-identifier=${networkIdentifierStr}`,
 					'--json',
 					'--offline',
-					'--data-path=/tmp',
+
 					'--network=devnet',
 				])
 				.it('should return signed transaction in json format', () => {

--- a/test/utils/transactions.ts
+++ b/test/utils/transactions.ts
@@ -35,6 +35,148 @@ const tokenTransferAsset = new TokenTransferAsset(BigInt(500000));
 export const tokenTransferAssetSchema = tokenTransferAsset.schema;
 export const keysRegisterAssetSchema = new KeysRegisterAsset().schema;
 export const dposVoteAssetSchema = new DPoSVoteAsset().schema;
+export const accountSchema = {
+	$id: '/account/base',
+	properties: {
+		address: {
+			dataType: 'bytes',
+			fieldNumber: 1,
+		},
+		dpos: {
+			fieldNumber: 5,
+			properties: {
+				delegate: {
+					fieldNumber: 1,
+					properties: {
+						consecutiveMissedBlocks: {
+							dataType: 'uint32',
+							fieldNumber: 3,
+						},
+						isBanned: {
+							dataType: 'boolean',
+							fieldNumber: 5,
+						},
+						lastForgedHeight: {
+							dataType: 'uint32',
+							fieldNumber: 4,
+						},
+						pomHeights: {
+							fieldNumber: 2,
+							items: {
+								dataType: 'uint32',
+							},
+							type: 'array',
+						},
+						totalVotesReceived: {
+							dataType: 'uint64',
+							fieldNumber: 6,
+						},
+						username: {
+							dataType: 'string',
+							fieldNumber: 1,
+						},
+					},
+					required: [
+						'username',
+						'pomHeights',
+						'consecutiveMissedBlocks',
+						'lastForgedHeight',
+						'isBanned',
+						'totalVotesReceived',
+					],
+					type: 'object',
+				},
+				sentVotes: {
+					fieldNumber: 2,
+					items: {
+						properties: {
+							amount: {
+								dataType: 'uint64',
+								fieldNumber: 2,
+							},
+							delegateAddress: {
+								dataType: 'bytes',
+								fieldNumber: 1,
+							},
+						},
+						required: ['delegateAddress', 'amount'],
+						type: 'object',
+					},
+					type: 'array',
+				},
+				unlocking: {
+					fieldNumber: 3,
+					items: {
+						properties: {
+							amount: {
+								dataType: 'uint64',
+								fieldNumber: 2,
+							},
+							delegateAddress: {
+								dataType: 'bytes',
+								fieldNumber: 1,
+							},
+							unvoteHeight: {
+								dataType: 'uint32',
+								fieldNumber: 3,
+							},
+						},
+						required: ['delegateAddress', 'amount', 'unvoteHeight'],
+						type: 'object',
+					},
+					type: 'array',
+				},
+			},
+			type: 'object',
+		},
+		keys: {
+			fieldNumber: 4,
+			properties: {
+				mandatoryKeys: {
+					fieldNumber: 2,
+					items: {
+						dataType: 'bytes',
+					},
+					type: 'array',
+				},
+				numberOfSignatures: {
+					dataType: 'uint32',
+					fieldNumber: 1,
+				},
+				optionalKeys: {
+					fieldNumber: 3,
+					items: {
+						dataType: 'bytes',
+					},
+					type: 'array',
+				},
+			},
+			type: 'object',
+		},
+		sequence: {
+			fieldNumber: 3,
+			properties: {
+				nonce: {
+					dataType: 'uint64',
+					fieldNumber: 1,
+				},
+			},
+			type: 'object',
+		},
+		token: {
+			fieldNumber: 2,
+			properties: {
+				balance: {
+					dataType: 'uint64',
+					fieldNumber: 1,
+				},
+			},
+			type: 'object',
+		},
+	},
+	required: ['address', 'token', 'sequence', 'keys', 'dpos'],
+	type: 'object',
+};
 
 export const genesisBlockID = Buffer.from(
 	'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',


### PR DESCRIPTION
### What was the problem?

This PR resolves #318 

### How was it solved?

- Allow transaction create and sign to be offline

### How was it tested?

- Updated unit test for transaction create and sign
- Added unit test for transaction create and sign offline
