### PR TITLE
Follow-up on #363: make workaround more reliable

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -19,7 +19,7 @@ ifeq ($(lisk_network),$(filter $(lisk_network),mainnet testnet betanet))
 	$(compose) run --rm --entrypoint /home/lisk/coldstart.sh lisk-task $(lisk_network)
 else
 	# workaround for https://github.com/LiskHQ/lisk-sdk/issues/5798
-	$(compose) run --rm --entrypoint /bin/rm lisk-task /home/lisk/.lisk/default/tmp/pids/controller.pid
+	$(compose) run --rm --entrypoint /bin/rm lisk-task -f /home/lisk/.lisk/default/tmp/pids/controller.pid
 	$(compose) run --rm lisk-task blockchain:reset --yes
 endif
 	docker-compose start lisk


### PR DESCRIPTION
### What was the problem?

The workaround for https://github.com/LiskHQ/lisk-sdk/issues/5798 introduced in #373 might itself cause a failure.

### How was it solved?

Pass the `-f` to `rm` so that it does not fail if the PID file is not present.

### How was it tested?

https://jenkins.lisk.io/job/lisk-desktop/job/PR-3060/7/console