### PR TITLE
Fix blockchain/forger-info export and import file name handling - Closes #389

### DIFF
--- a/src/commands/blockchain/export.ts
+++ b/src/commands/blockchain/export.ts
@@ -47,16 +47,17 @@ export default class ExportCommand extends Command {
 
 		this.log('Exporting blockchain:');
 		this.log(`   ${getFullPath(blockchainPath)}`);
+		const filePath = join(exportPath, 'blockchain.db.tar.gz');
 		await tar.create(
 			{
 				gzip: true,
-				file: join(exportPath, 'blockchain.db.tar.gz'),
+				file: filePath,
 				cwd: join(dataPath, 'data'),
 			},
 			['blockchain.db'],
 		);
 
 		this.log('Export completed:');
-		this.log(`   ${getFullPath(exportPath)}/blockchain.db.tar.gz`);
+		this.log(`   ${filePath}`);
 	}
 }

--- a/src/commands/blockchain/import.ts
+++ b/src/commands/blockchain/import.ts
@@ -59,16 +59,17 @@ export default class ImportCommand extends Command {
 			this.error('The blockchain data file must be a gzip file.');
 		}
 
-		if (!flags.force && fs.existsSync(blockchainDBPath)) {
-			const errorMessage = `There is already a blockchain data file found at ${dataPath}. Use --force to override.`;
-
-			this.error(errorMessage);
+		if (fs.existsSync(blockchainDBPath)) {
+			if (!flags.force) {
+				this.error(`There is already a blockchain data file found at ${dataPath}. Use --force to override.`);
+			}
+			fs.removeSync(blockchainDBPath);
 		}
 
 		fs.ensureDirSync(blockchainDBPath);
 		this.log(`Importing blockchain from ${getFullPath(filepath)}`);
 
-		await extract(path.dirname(filepath), 'blockchain.db.gz', blockchainDBPath);
+		await extract(path.dirname(filepath), path.basename(filepath), blockchainDBPath);
 
 		this.log('Import completed.');
 		this.log(`   ${getFullPath(dataPath)}`);

--- a/src/commands/blockchain/import.ts
+++ b/src/commands/blockchain/import.ts
@@ -61,7 +61,9 @@ export default class ImportCommand extends Command {
 
 		if (fs.existsSync(blockchainDBPath)) {
 			if (!flags.force) {
-				this.error(`There is already a blockchain data file found at ${dataPath}. Use --force to override.`);
+				this.error(
+					`There is already a blockchain data file found at ${dataPath}. Use --force to override.`,
+				);
 			}
 			fs.removeSync(blockchainDBPath);
 		}

--- a/src/commands/forger-info/export.ts
+++ b/src/commands/forger-info/export.ts
@@ -47,16 +47,17 @@ export default class ExportCommand extends Command {
 
 		this.log('Exporting ForgerInfo:');
 		this.log(`   ${getFullPath(forgerDataPath)}`);
+		const filePath = join(exportPath, 'forger.db.tar.gz');
 		await tar.create(
 			{
 				gzip: true,
-				file: join(exportPath, 'forger.db.gz'),
+				file: filePath,
 				cwd: join(dataPath, 'data'),
 			},
 			['forger.db'],
 		);
 
 		this.log('Export completed:');
-		this.log(`   ${getFullPath(exportPath)}`);
+		this.log(`   ${filePath}`);
 	}
 }

--- a/src/commands/forger-info/import.ts
+++ b/src/commands/forger-info/import.ts
@@ -61,14 +61,17 @@ export default class ImportCommand extends Command {
 			this.error('Forger data should be provided in gzip format.');
 		}
 
-		if (!flags.force && fs.existsSync(forgerDBPath)) {
-			this.error(`Forger data already exists at ${dataPath}. Use --force flag to overwrite`);
+		if (fs.existsSync(forgerDBPath)) {
+			if (!flags.force) {
+				this.error(`Forger data already exists at ${dataPath}. Use --force flag to overwrite`);
+			}
+			fs.removeSync(forgerDBPath);
 		}
 
 		fs.ensureDirSync(forgerDBPath);
 		this.log(`Importing forger data from ${getFullPath(sourcePath)}`);
 
-		await downloadUtils.extract(path.dirname(sourcePath), 'forger.db.gz', forgerDBPath);
+		await downloadUtils.extract(path.dirname(sourcePath), path.basename(sourcePath), forgerDBPath);
 
 		this.log('Import completed.');
 		this.log(`   ${getFullPath(dataPath)}`);

--- a/src/utils/download.ts
+++ b/src/utils/download.ts
@@ -105,7 +105,7 @@ export const downloadAndValidate = async (url: string, dir: string): Promise<voi
 
 export const extract = async (filePath: string, fileName: string, outDir: string): Promise<void> =>
 	tar.x({
-		file: `${filePath}/${fileName}`,
+		file: path.join(filePath, fileName),
 		cwd: outDir,
 		strip: 1,
 	});

--- a/test/commands/blockchain/import.spec.ts
+++ b/test/commands/blockchain/import.spec.ts
@@ -23,7 +23,7 @@ import * as downloadUtils from '../../../src/utils/download';
 
 const defaultDataPath = path.join(homedir(), '.lisk', 'lisk-core');
 const defaultBlockchainDBPath = getBlockchainDBPath(defaultDataPath);
-const pathToBlockchainGzip = '/path/to/blockchain.db.gz';
+const pathToBlockchainGzip = '/path/to/blockchain.db.tar.gz';
 
 describe('blockchain:import', () => {
 	const fsExistsSyncStub = sandbox.stub().returns(false);
@@ -34,6 +34,7 @@ describe('blockchain:import', () => {
 	const setupTest = () =>
 		test
 			.stub(fs, 'existsSync', fsExistsSyncStub)
+			.stub(fs, 'removeSync', sandbox.stub())
 			.stub(path, 'extname', pathExtnameStub)
 			.stub(fs, 'ensureDirSync', fsEnsureDirSyncStub)
 			.stub(downloadUtils, 'extract', extractStub)
@@ -65,7 +66,7 @@ describe('blockchain:import', () => {
 				expect(extractStub).to.have.been.calledOnce;
 				expect(extractStub).to.have.been.calledWithExactly(
 					path.dirname(pathToBlockchainGzip),
-					'blockchain.db.gz',
+					'blockchain.db.tar.gz',
 					defaultBlockchainDBPath,
 				);
 			});
@@ -83,7 +84,7 @@ describe('blockchain:import', () => {
 				expect(extractStub).to.have.been.calledOnce;
 				expect(extractStub).to.have.been.calledWithExactly(
 					path.dirname(pathToBlockchainGzip),
-					'blockchain.db.gz',
+					'blockchain.db.tar.gz',
 					dataPath,
 				);
 			});
@@ -112,9 +113,10 @@ describe('blockchain:import', () => {
 					expect(fsEnsureDirSyncStub).to.have.been.calledOnce;
 					expect(fsEnsureDirSyncStub).to.have.been.calledWithExactly(defaultBlockchainDBPath);
 					expect(extractStub).to.have.been.calledOnce;
+					expect(fs.removeSync).to.have.been.calledWithExactly(defaultBlockchainDBPath);
 					expect(extractStub).to.have.been.calledWithExactly(
 						path.dirname(pathToBlockchainGzip),
-						'blockchain.db.gz',
+						'blockchain.db.tar.gz',
 						defaultBlockchainDBPath,
 					);
 				});

--- a/test/commands/forger-info/export.spec.ts
+++ b/test/commands/forger-info/export.spec.ts
@@ -38,7 +38,7 @@ describe('forger-info:export', () => {
 				expect(tarCreateStub).to.have.been.calledWithExactly(
 					{
 						cwd: join(defaultDataPath, 'data'),
-						file: join(process.cwd(), 'forger.db.gz'),
+						file: join(process.cwd(), 'forger.db.tar.gz'),
 						gzip: true,
 					},
 					['forger.db'],
@@ -54,7 +54,7 @@ describe('forger-info:export', () => {
 				expect(tarCreateStub).to.have.been.calledWithExactly(
 					{
 						cwd: join('/my/app/', 'data'),
-						file: join(process.cwd(), 'forger.db.gz'),
+						file: join(process.cwd(), 'forger.db.tar.gz'),
 						gzip: true,
 					},
 					['forger.db'],
@@ -70,7 +70,7 @@ describe('forger-info:export', () => {
 				expect(tarCreateStub).to.have.been.calledWithExactly(
 					{
 						cwd: join(defaultDataPath, 'data'),
-						file: join('/my/dir/', 'forger.db.gz'),
+						file: join('/my/dir/', 'forger.db.tar.gz'),
 						gzip: true,
 					},
 					['forger.db'],

--- a/test/commands/forger-info/import.spec.ts
+++ b/test/commands/forger-info/import.spec.ts
@@ -23,7 +23,7 @@ import * as downloadUtils from '../../../src/utils/download';
 
 const defaultDataPath = path.join(homedir(), '.lisk', 'lisk-core');
 const defaultForgerDBPath = getForgerDBPath(defaultDataPath);
-const pathToForgerGzip = '/path/to/forger.db.gz';
+const pathToForgerGzip = '/path/to/forger.db.tar.gz';
 
 describe('forger-info:import', () => {
 	const fsExistsSyncStub = sandbox.stub().returns(false);
@@ -34,6 +34,7 @@ describe('forger-info:import', () => {
 	const setupTest = () =>
 		test
 			.stub(fs, 'existsSync', fsExistsSyncStub)
+			.stub(fs, 'removeSync', sandbox.stub())
 			.stub(path, 'extname', pathExtnameStub)
 			.stub(fs, 'ensureDirSync', fsEnsureDirSyncStub)
 			.stub(downloadUtils, 'extract', extractStub)
@@ -65,7 +66,7 @@ describe('forger-info:import', () => {
 				expect(extractStub).to.have.been.calledOnce;
 				expect(extractStub).to.have.been.calledWithExactly(
 					path.dirname(pathToForgerGzip),
-					'forger.db.gz',
+					'forger.db.tar.gz',
 					defaultForgerDBPath,
 				);
 			});
@@ -83,7 +84,7 @@ describe('forger-info:import', () => {
 				expect(extractStub).to.have.been.calledOnce;
 				expect(extractStub).to.have.been.calledWithExactly(
 					path.dirname(pathToForgerGzip),
-					'forger.db.gz',
+					'forger.db.tar.gz',
 					dataPath,
 				);
 			});
@@ -112,9 +113,10 @@ describe('forger-info:import', () => {
 					expect(fsEnsureDirSyncStub).to.have.been.calledOnce;
 					expect(fsEnsureDirSyncStub).to.have.been.calledWithExactly(defaultForgerDBPath);
 					expect(extractStub).to.have.been.calledOnce;
+					expect(fs.removeSync).to.have.been.calledWithExactly(defaultForgerDBPath);
 					expect(extractStub).to.have.been.calledWithExactly(
 						path.dirname(pathToForgerGzip),
-						'forger.db.gz',
+						'forger.db.tar.gz',
 						defaultForgerDBPath,
 					);
 				});


### PR DESCRIPTION
### What was the problem?

This PR resolves #389 

### How was it solved?

- Update when `force` is true, remove the existing folder
- Update not to use fixed name while importing
- Fix `db.gz` naming for forger-info export

### How was it tested?

Start a node and forge few blocks
```
./bin/run blockchain:export
rm -rf ~/.lisk/lisk-core/data
./bin/run blockchain:import ./blockchain.db.tar.gz
./bin/run forger-info:export
./bin/run forger-info:import ./forger.db.tar.gz
```
and run and check if it is correctly restored
