### PR TITLE
Update core flags in docker file - Closes #392

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,5 +31,5 @@ USER lisk
 RUN mkdir /home/lisk/.lisk
 VOLUME ["/home/lisk/.lisk"]
 
-ENTRYPOINT ["/home/lisk/node_modules/.bin/lisk-core", "start", "--enable-http-api"]
+ENTRYPOINT ["/home/lisk/node_modules/.bin/lisk-core", "start", "--enable-http-api-plugin"]
 CMD ["--network", "mainnet"]


### PR DESCRIPTION
### What was the problem?

This PR resolves #392 

### How was it solved?

- Updated flag name

### How was it tested?
- Ensure docker server is running
- cd docker
- cp .env.development .env
- make mrproper
- make build
- make logs