### PR TITLE
Enable api-ws and port for start command - Closes #409 

### DIFF
--- a/Jenkinsfile.ci
+++ b/Jenkinsfile.ci
@@ -27,7 +27,6 @@ pipeline {
 						npm install --global yarn
 						yarn
 						yarn build
-						npx lerna exec yarn unlink
 						npx lerna exec yarn link
 						npx lerna --loglevel error list >../packages
 						'''

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -143,14 +143,12 @@ export default class StartCommand extends Command {
 			exclusive: ['api-ws'],
 		}),
 		'api-ws': flagParser.boolean({
-			description:
-				'Enable websocket communication for api-client.',
+			description: 'Enable websocket communication for api-client.',
 			default: false,
 			exclusive: ['enable-ipc'],
 		}),
 		'api-ws-port': flagParser.integer({
-			description:
-				'Port to be used for api-client websocket.',
+			description: 'Port to be used for api-client websocket.',
 			dependsOn: ['api-ws'],
 		}),
 		'console-log': flagParser.string({

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -140,12 +140,13 @@ export default class StartCommand extends Command {
 			description:
 				'Enable IPC communication. This will also load up plugins in child process and communicate over IPC.',
 			default: false,
+			exclusive: ['api-ws'],
 		}),
 		'api-ws': flagParser.boolean({
 			description:
 				'Enable websocket communication for api-client.',
 			default: false,
-			exclusive: ['api-ipc'],
+			exclusive: ['enable-ipc'],
 		}),
 		'api-ws-port': flagParser.integer({
 			description:

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -318,7 +318,7 @@ export default class StartCommand extends Command {
 			config.ipc = { enabled: flags['enable-ipc'] };
 		}
 		if (flags['api-ws']) {
-			config.rpc = { enabled: flags['api-ws'], mode: 'ws', port: flags['api-ws-port'] ?? 8080 };
+			config.rpc = { enabled: flags['api-ws'], mode: 'ws', port: flags['api-ws-port'] };
 		}
 		if (flags['console-log']) {
 			// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -141,6 +141,17 @@ export default class StartCommand extends Command {
 				'Enable IPC communication. This will also load up plugins in child process and communicate over IPC.',
 			default: false,
 		}),
+		'api-ws': flagParser.boolean({
+			description:
+				'Enable websocket communication for api-client.',
+			default: false,
+			exclusive: ['api-ipc'],
+		}),
+		'api-ws-port': flagParser.integer({
+			description:
+				'Port to be used for api-client websocket.',
+			dependsOn: ['api-ws'],
+		}),
 		'console-log': flagParser.string({
 			description:
 				'Console log level. Environment variable "LISK_CONSOLE_LOG_LEVEL" can also be used.',
@@ -305,6 +316,9 @@ export default class StartCommand extends Command {
 		// Inject other properties specified
 		if (flags['enable-ipc']) {
 			config.ipc = { enabled: flags['enable-ipc'] };
+		}
+		if (flags['api-ws']) {
+			config.rpc = { enabled: flags['api-ws'], mode: 'ws', port: flags['api-ws-port'] ?? 8080 };
 		}
 		if (flags['console-log']) {
 			// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition

--- a/test/commands/start.spec.ts
+++ b/test/commands/start.spec.ts
@@ -118,6 +118,26 @@ describe('start', () => {
 		});
 	});
 
+	describe('when --api-ws is specified', () => {
+		it('should update the config value', async () => {
+			await StartCommand.run(['--api-ws'], config);
+			const [, usedConfig] = (application.getApplication as jest.Mock).mock.calls[0];
+			expect(usedConfig.rpc.enabled).toBe(true);
+			expect(usedConfig.rpc.mode).toBe('ws');
+		});
+	});
+
+	describe('when custom port with --api-ws-port is specified along with --api-ws', () => {
+		it('should update the config value', async () => {
+			await StartCommand.run(
+				['--api-ws', '--api-ws-port', '8888'],
+				config,
+			);
+			const [, usedConfig] = (application.getApplication as jest.Mock).mock.calls[0];
+			expect(usedConfig.rpc.port).toBe(8888);
+		});
+	});
+
 	describe('when --enable-http-api-plugin is specified', () => {
 		it('should pass this value to configuration', async () => {
 			await StartCommand.run(['--enable-http-api-plugin'], config);

--- a/test/commands/start.spec.ts
+++ b/test/commands/start.spec.ts
@@ -129,10 +129,7 @@ describe('start', () => {
 
 	describe('when custom port with --api-ws-port is specified along with --api-ws', () => {
 		it('should update the config value', async () => {
-			await StartCommand.run(
-				['--api-ws', '--api-ws-port', '8888'],
-				config,
-			);
+			await StartCommand.run(['--api-ws', '--api-ws-port', '8888'], config);
 			const [, usedConfig] = (application.getApplication as jest.Mock).mock.calls[0];
 			expect(usedConfig.rpc.port).toBe(8888);
 		});


### PR DESCRIPTION
### What was the problem?

This PR resolves #409 

### How was it solved?

-  Add enable api-ws flag
-  Add enable api-ws-port flag
-  Add tests for api-ws and api-ws-port

### How was it tested?

Run `start` command with appropriate flags and observe.