### PR TITLE
Fix symlink path - Closes #407

### DIFF
--- a/src/commands/sdk/link.ts
+++ b/src/commands/sdk/link.ts
@@ -15,7 +15,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { Command } from '@oclif/command';
-import { symlinkSync, pathExistsSync, removeSync } from 'fs-extra';
+import { symlink, pathExistsSync, removeSync } from 'fs-extra';
 import { join } from 'path';
 
 export default class LinkCommand extends Command {
@@ -39,8 +39,9 @@ export default class LinkCommand extends Command {
 
 		const sdkLocalPath = join(__dirname, '../../../', 'node_modules', 'lisk-sdk');
 
+		const targetSDKFolderFromNodeModule = join('../', targetSDKFolder);
 		removeSync(sdkLocalPath);
-		symlinkSync(targetSDKFolder, sdkLocalPath);
+		await symlink(targetSDKFolderFromNodeModule, sdkLocalPath);
 		this.log(`Linked '${targetSDKFolder as string}' to '${sdkLocalPath}'`);
 	}
 }

--- a/test/commands/sdk/link.spec.ts
+++ b/test/commands/sdk/link.spec.ts
@@ -31,7 +31,7 @@ describe('sdk:link command', () => {
 		jest.spyOn(process.stdout, 'write').mockImplementation(val => stdout.push(val as string) > -1);
 		jest.spyOn(process.stderr, 'write').mockImplementation(val => stderr.push(val as string) > -1);
 		jest.spyOn(fs, 'removeSync').mockReturnValue();
-		jest.spyOn(fs, 'symlinkSync').mockReturnValue();
+		jest.spyOn(fs, 'symlink').mockResolvedValue();
 	});
 
 	describe('sdk:link', () => {
@@ -66,7 +66,7 @@ describe('sdk:link command', () => {
 			await LinkCommand.run([fakeSDKPath], config);
 			expect(fs.pathExistsSync).toHaveBeenCalledWith(fakeSDKPath);
 			expect(fs.removeSync).toHaveBeenCalledWith(targetSDKPath);
-			expect(fs.symlinkSync).toHaveBeenCalledWith(fakeSDKPath, targetSDKPath);
+			expect(fs.symlink).toHaveBeenCalledWith(join('../', fakeSDKPath), targetSDKPath);
 			expect(stdout[0]).toContain(`Linked '/path/exists' to '${targetSDKPath}'`);
 		});
 	});


### PR DESCRIPTION
### What was the problem?

This PR resolves #407 

### How was it solved?

- Update symlink to reference from the node_modules, where it was the path from the root folder

### How was it tested?

- rm -rf node_modules
- npm i --registry https://npm.lisk.io
- ./bin/run sdk:link ../lisk-sdk/sdk
- npm run build
