### PR TITLE
Add action get unregistered Account- Closes #408

### DIFF
--- a/src/application/modules/legacy_account/legacy_account_module.ts
+++ b/src/application/modules/legacy_account/legacy_account_module.ts
@@ -24,7 +24,7 @@ export class LegacyAccountModule extends BaseModule {
 	public transactionAssets = [new ReclaimAsset()];
 
 	public actions: Actions = {
-		getUnregisteredAccount: async (params: Record<string, unknown>): Promise<{ address: string, balance: string } | undefined> => {
+		getUnregisteredAccount: async (params: Record<string, unknown>): Promise<{ address: string; balance: string } | undefined> => {
 			if (!params?.publicKey || typeof params?.publicKey !== 'string') {
 				throw new Error('Public key is either not provided or not a string');
 			}
@@ -40,17 +40,17 @@ export class LegacyAccountModule extends BaseModule {
 				encodedUnregisteredAddresses,
 			);
 
-			const legacyAddress = getLegacyBytes(Buffer.from(params.publicKey as string, 'hex'));
+			const legacyAddress = getLegacyBytes(Buffer.from(params.publicKey, 'hex'));
 			const addressWithoutPublickey = unregisteredAddresses.find(a =>
 				a.address.equals(legacyAddress),
 			);
 
 			return addressWithoutPublickey ? {
-				address: addressWithoutPublickey?.address.toString('hex'),
+				address: addressWithoutPublickey.address.toString('hex'),
 				balance: addressWithoutPublickey.balance.toString(),
-			}: undefined;
-		}
-	}
+			} : undefined;
+		},
+	};
 	// eslint-disable-next-line class-methods-use-this
 	public async afterGenesisBlockApply({
 		genesisBlock,

--- a/src/application/modules/legacy_account/legacy_account_module.ts
+++ b/src/application/modules/legacy_account/legacy_account_module.ts
@@ -24,12 +24,16 @@ export class LegacyAccountModule extends BaseModule {
 	public transactionAssets = [new ReclaimAsset()];
 
 	public actions: Actions = {
-		getUnregisteredAccount: async (params: Record<string, unknown>): Promise<{ address: string; balance: string } | undefined> => {
+		getUnregisteredAccount: async (
+			params: Record<string, unknown>,
+		): Promise<{ address: string; balance: string } | undefined> => {
 			if (!params?.publicKey || typeof params?.publicKey !== 'string') {
 				throw new Error('Public key is either not provided or not a string');
 			}
 
-			const encodedUnregisteredAddresses: Buffer | undefined = await this._dataAccess.getChainState(CHAIN_STATE_UNREGISTERED_ADDRESSES);
+			const encodedUnregisteredAddresses: Buffer | undefined = await this._dataAccess.getChainState(
+				CHAIN_STATE_UNREGISTERED_ADDRESSES,
+			);
 
 			if (!encodedUnregisteredAddresses) {
 				throw new Error('Chain state does not contain any unregistered addresses');
@@ -45,10 +49,12 @@ export class LegacyAccountModule extends BaseModule {
 				a.address.equals(legacyAddress),
 			);
 
-			return addressWithoutPublickey ? {
-				address: addressWithoutPublickey.address.toString('hex'),
-				balance: addressWithoutPublickey.balance.toString(),
-			} : undefined;
+			return addressWithoutPublickey
+				? {
+						address: addressWithoutPublickey.address.toString('hex'),
+						balance: addressWithoutPublickey.balance.toString(),
+				  }
+				: undefined;
 		},
 	};
 	// eslint-disable-next-line class-methods-use-this

--- a/src/application/modules/legacy_account/legacy_account_module.ts
+++ b/src/application/modules/legacy_account/legacy_account_module.ts
@@ -24,7 +24,11 @@ export class LegacyAccountModule extends BaseModule {
 	public transactionAssets = [new ReclaimAsset()];
 
 	public actions: Actions = {
-		getUnregisteredAccount: async (params: Record<string, unknown>) => {
+		getUnregisteredAccount: async (params: Record<string, unknown>): Promise<{ address: string, balance: string } | undefined> => {
+			if (!params?.publicKey || typeof params?.publicKey !== 'string') {
+				throw new Error('Public key is either not provided or not a string');
+			}
+
 			const encodedUnregisteredAddresses: Buffer | undefined = await this._dataAccess.getChainState(CHAIN_STATE_UNREGISTERED_ADDRESSES);
 
 			if (!encodedUnregisteredAddresses) {
@@ -41,7 +45,10 @@ export class LegacyAccountModule extends BaseModule {
 				a.address.equals(legacyAddress),
 			);
 
-			return addressWithoutPublickey;
+			return addressWithoutPublickey ? {
+				address: addressWithoutPublickey?.address.toString('hex'),
+				balance: addressWithoutPublickey.balance.toString(),
+			}: undefined;
 		}
 	}
 	// eslint-disable-next-line class-methods-use-this

--- a/src/application/modules/legacy_account/transaction_assets/reclaim_asset.ts
+++ b/src/application/modules/legacy_account/transaction_assets/reclaim_asset.ts
@@ -15,18 +15,10 @@
 import { ApplyAssetContext, BaseAsset, codec, cryptography } from 'lisk-sdk';
 import { CHAIN_STATE_UNREGISTERED_ADDRESSES } from '../constants';
 import { reclaimAssetSchema, unregisteredAddressesSchema } from '../schema';
+import { UnregisteredAddresses } from '../types';
 
 interface Asset {
 	readonly amount: bigint;
-}
-
-interface UnregisteredAccount {
-	readonly address: Buffer;
-	readonly balance: bigint;
-}
-
-interface UnregisteredAddresses {
-	readonly unregisteredAddresses: UnregisteredAccount[];
 }
 
 export const getLegacyBytes = (publicKey: string | Buffer): Buffer =>

--- a/src/application/modules/legacy_account/types.ts
+++ b/src/application/modules/legacy_account/types.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+export interface UnregisteredAccount {
+	readonly address: Buffer;
+	readonly balance: bigint;
+}
+
+export interface UnregisteredAddresses {
+	readonly unregisteredAddresses: UnregisteredAccount[];
+}

--- a/test/application/modules/legacy_account/legacy_account_module.spec.ts
+++ b/test/application/modules/legacy_account/legacy_account_module.spec.ts
@@ -127,4 +127,45 @@ describe('LegacyAccountModule', () => {
 			).rejects.toThrow('Account not defined');
 		});
 	});
+
+	describe('getUnregisteredAccount', () => {
+		const dataAccessMock = {
+			getChainState: jest.fn(),
+		};
+		const unregisteredAccount = createAccount();
+		unregisteredAccount.address = getLegacyBytes(unregisteredAccount.publicKey);
+
+		const unregisteredAddressWithBalance = {
+			address: unregisteredAccount.address,
+			balance: BigInt(200000000000),
+		};
+
+		const encodedUnregisteredAddresses = codec.encode(unregisteredAddressesSchema, {
+			unregisteredAddresses: [unregisteredAddressWithBalance],
+		});
+
+		beforeEach(() => {
+			(legacyAccountModule as any)['_dataAccess'] = dataAccessMock;
+			dataAccessMock.getChainState.mockResolvedValue(encodedUnregisteredAddresses);
+		});
+
+		it('should return the unregistered address', async () => {
+			// Act
+			const legacyAccount = await legacyAccountModule.actions.getUnregisteredAccount({ publicKey: unregisteredAccount.publicKey.toString('hex') });
+
+			// Assert
+			expect(legacyAccount).toEqual(unregisteredAddressWithBalance);
+		});
+
+		it('should return undefined when not found in unregisteredAddresses list', async () => {
+			// Arrange
+			const randomAccount = createAccount();
+
+			// Act
+			const legacyAccount = await legacyAccountModule.actions.getUnregisteredAccount({ publicKey: randomAccount.publicKey.toString('hex') });
+
+			// Assert
+			expect(legacyAccount).toBeUndefined;
+		});
+	});
 });

--- a/test/application/modules/legacy_account/legacy_account_module.spec.ts
+++ b/test/application/modules/legacy_account/legacy_account_module.spec.ts
@@ -165,10 +165,10 @@ describe('LegacyAccountModule', () => {
 			const randomAccount = createAccount();
 
 			// Act
-			const legacyAccount = await legacyAccountModule.actions.getUnregisteredAccount({ publicKey: randomAccount.publicKey.toString('hex') });
+			const legacyAccount = await legacyAccountModule.actions.getUnregisteredAccount({ publicKey: randomAccount.publicKey.toString('hex') }) as { address: string; balance: string};
 
 			// Assert
-			expect(legacyAccount).toBeUndefined;
+			return expect(legacyAccount).toBeUndefined();
 		});
 
 		it('should throw an error when publicKey is not provided', async () => {

--- a/test/application/modules/legacy_account/legacy_account_module.spec.ts
+++ b/test/application/modules/legacy_account/legacy_account_module.spec.ts
@@ -151,7 +151,9 @@ describe('LegacyAccountModule', () => {
 
 		it('should return the unregistered address', async () => {
 			// Act
-			const legacyAccount = await legacyAccountModule.actions.getUnregisteredAccount({ publicKey: unregisteredAccount.publicKey.toString('hex') });
+			const legacyAccount = await legacyAccountModule.actions.getUnregisteredAccount({
+				publicKey: unregisteredAccount.publicKey.toString('hex'),
+			});
 
 			// Assert
 			expect(legacyAccount).toEqual({
@@ -165,7 +167,9 @@ describe('LegacyAccountModule', () => {
 			const randomAccount = createAccount();
 
 			// Act
-			const legacyAccount = await legacyAccountModule.actions.getUnregisteredAccount({ publicKey: randomAccount.publicKey.toString('hex') }) as { address: string; balance: string};
+			const legacyAccount = (await legacyAccountModule.actions.getUnregisteredAccount({
+				publicKey: randomAccount.publicKey.toString('hex'),
+			})) as { address: string; balance: string };
 
 			// Assert
 			return expect(legacyAccount).toBeUndefined();
@@ -173,12 +177,16 @@ describe('LegacyAccountModule', () => {
 
 		it('should throw an error when publicKey is not provided', async () => {
 			// Assert
-			await expect(legacyAccountModule.actions.getUnregisteredAccount({})).rejects.toThrow('Public key is either not provided or not a string');
+			await expect(legacyAccountModule.actions.getUnregisteredAccount({})).rejects.toThrow(
+				'Public key is either not provided or not a string',
+			);
 		});
 
 		it('should throw an error when publicKey is not a string', async () => {
 			// Assert
-			await expect(legacyAccountModule.actions.getUnregisteredAccount({ publicKey: Buffer.from('') })).rejects.toThrow('Public key is either not provided or not a string');
+			await expect(
+				legacyAccountModule.actions.getUnregisteredAccount({ publicKey: Buffer.from('') }),
+			).rejects.toThrow('Public key is either not provided or not a string');
 		});
 	});
 });

--- a/test/application/modules/legacy_account/legacy_account_module.spec.ts
+++ b/test/application/modules/legacy_account/legacy_account_module.spec.ts
@@ -154,7 +154,10 @@ describe('LegacyAccountModule', () => {
 			const legacyAccount = await legacyAccountModule.actions.getUnregisteredAccount({ publicKey: unregisteredAccount.publicKey.toString('hex') });
 
 			// Assert
-			expect(legacyAccount).toEqual(unregisteredAddressWithBalance);
+			expect(legacyAccount).toEqual({
+				address: unregisteredAddressWithBalance.address.toString('hex'),
+				balance: unregisteredAddressWithBalance.balance.toString(),
+			});
 		});
 
 		it('should return undefined when not found in unregisteredAddresses list', async () => {
@@ -166,6 +169,16 @@ describe('LegacyAccountModule', () => {
 
 			// Assert
 			expect(legacyAccount).toBeUndefined;
+		});
+
+		it('should throw an error when publicKey is not provided', async () => {
+			// Assert
+			await expect(legacyAccountModule.actions.getUnregisteredAccount({})).rejects.toThrow('Public key is either not provided or not a string');
+		});
+
+		it('should throw an error when publicKey is not a string', async () => {
+			// Assert
+			await expect(legacyAccountModule.actions.getUnregisteredAccount({ publicKey: Buffer.from('') })).rejects.toThrow('Public key is either not provided or not a string');
 		});
 	});
 });


### PR DESCRIPTION
### What was the problem?

This PR resolves #408 

### How was it solved?

♻️   Move types to types.ts to reuse 9f24f9f

🌱   Add getUnregisteredAccount action to legacyAccountModule 63e4e7b

✅   Add test for getUnregisteredAccount 300e43d

### How was it tested?

`npm run test legacy_account_module.spec.ts`
