### PR TITLE
Fix property ws config property name - Closes #416

### DIFF
--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -317,7 +317,7 @@ export default class StartCommand extends Command {
 			config.ipc = { enabled: flags['enable-ipc'] };
 		}
 		if (flags['api-ws']) {
-			config.rpc = { enabled: flags['api-ws'], mode: 'ws', port: flags['api-ws-port'] };
+			config.rpc = { enable: flags['api-ws'], mode: 'ws', port: flags['api-ws-port'] };
 		}
 		if (flags['console-log']) {
 			// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition

--- a/test/commands/start.spec.ts
+++ b/test/commands/start.spec.ts
@@ -122,7 +122,7 @@ describe('start', () => {
 		it('should update the config value', async () => {
 			await StartCommand.run(['--api-ws'], config);
 			const [, usedConfig] = (application.getApplication as jest.Mock).mock.calls[0];
-			expect(usedConfig.rpc.enabled).toBe(true);
+			expect(usedConfig.rpc.enable).toBe(true);
 			expect(usedConfig.rpc.mode).toBe('ws');
 		});
 	});


### PR DESCRIPTION
### What was the problem?

This PR resolves #416 

### How was it solved?

Fix the test and config property

### How was it tested?
```
./bin/run start -n alphanet --api-ws
```
and connect with ws api client