### PR TITLE
Typo in error message on reclaim asset - Closes #422

### DIFF
--- a/src/application/modules/legacy_account/transaction_assets/reclaim_asset.ts
+++ b/src/application/modules/legacy_account/transaction_assets/reclaim_asset.ts
@@ -41,7 +41,7 @@ export class ReclaimAsset extends BaseAsset<Asset> {
 		);
 
 		if (!encodedUnregisteredAddresses) {
-			throw new Error('Chain state does not contain any unregistered addresses');
+			throw new Error('Chain state does not contain any unregistered addresses.');
 		}
 		const { unregisteredAddresses } = codec.decode<UnregisteredAddresses>(
 			unregisteredAddressesSchema,
@@ -54,7 +54,7 @@ export class ReclaimAsset extends BaseAsset<Asset> {
 
 		if (!addressWithoutPublickey) {
 			throw new Error(
-				'Legacy address corresponding to sender publickey was not found genesis account state',
+				'Legacy address corresponding to sender publickey was not found in the genesis account state.',
 			);
 		}
 		if (asset.amount !== addressWithoutPublickey.balance) {
@@ -62,7 +62,7 @@ export class ReclaimAsset extends BaseAsset<Asset> {
 				`Invalid amount:${
 					// eslint-disable-next-line @typescript-eslint/restrict-template-expressions
 					asset.amount.toString()
-				} claimed by the sender: ${addressWithoutPublickey.address.toString('hex')}`,
+				} claimed by the sender: ${addressWithoutPublickey.address.toString('hex')}.`,
 			);
 		}
 		const newAddress = cryptography.getAddressFromPublicKey(senderPublicKey);

--- a/test/application/modules/legacy_account/reclaim_asset.spec.ts
+++ b/test/application/modules/legacy_account/reclaim_asset.spec.ts
@@ -87,7 +87,7 @@ describe('ReclaimAsset', () => {
 				chain: {},
 			}) as any;
 			await expect(reclaimAsset.apply(reclaimAssetInput)).rejects.toThrow(
-				'Chain state does not contain any unregistered addresses',
+				'Chain state does not contain any unregistered addresses.',
 			);
 		});
 
@@ -104,7 +104,7 @@ describe('ReclaimAsset', () => {
 				chain: chainMockData,
 			}) as any;
 			await expect(reclaimAsset.apply(reclaimAssetInput)).rejects.toThrow(
-				'Legacy address corresponding to sender publickey was not found genesis account state',
+				'Legacy address corresponding to sender publickey was not found in the genesis account state.',
 			);
 		});
 
@@ -121,7 +121,9 @@ describe('ReclaimAsset', () => {
 				chain: chainMockData,
 			}) as any;
 			await expect(reclaimAsset.apply(reclaimAssetInput)).rejects.toThrow(
-				'Invalid amount:100000000000 claimed by the sender',
+				`Invalid amount:100000000000 claimed by the sender: ${getLegacyBytes(
+					defaultAccount.publicKey,
+				).toString('hex')}.`,
 			);
 		});
 
@@ -141,7 +143,7 @@ describe('ReclaimAsset', () => {
 		it('should fail to reclaim twice for same account', async () => {
 			await reclaimAsset.apply(reclaimAssetInput);
 			await expect(reclaimAsset.apply(reclaimAssetInput)).rejects.toThrow(
-				'Legacy address corresponding to sender publickey was not found genesis account state',
+				'Legacy address corresponding to sender publickey was not found in the genesis account state.',
 			);
 			await expect(
 				reclaimAssetInput.stateStore.chain.get(CHAIN_STATE_UNREGISTERED_ADDRESSES),


### PR DESCRIPTION
### What was the problem?

This PR resolves #422 

### How was it solved?

:recycle: Fix typo and update tests

### How was it tested?

- Updated unit tests