### PR TITLE
Rename enable-ipc to api-ipc - Closes #410

### DIFF
--- a/config/alphanet/config.json
+++ b/config/alphanet/config.json
@@ -30,8 +30,7 @@
 	},
 	"rpc": {
 		"enable": false,
-		"mode": "ipc",
-		"port": 8080
+		"mode": "ipc"
 	},
 	"network": {
 		"port": 5000,

--- a/config/alphanet/config.json
+++ b/config/alphanet/config.json
@@ -1,7 +1,4 @@
 {
-	"ipc": {
-		"enabled": false
-	},
 	"networkVersion": "2.0",
 	"label": "devnet",
 	"genesisConfig": {
@@ -30,6 +27,11 @@
 	"logger": {
 		"fileLogLevel": "debug",
 		"consoleLogLevel": "info"
+	},
+	"rpc": {
+		"enable": false,
+		"mode": "ipc",
+		"port": 8080
 	},
 	"network": {
 		"port": 5000,

--- a/config/devnet/config.json
+++ b/config/devnet/config.json
@@ -30,8 +30,7 @@
 	},
 	"rpc": {
 		"enable": false,
-		"mode": "ipc",
-		"port": 8080
+		"mode": "ipc"
 	},
 	"network": {
 		"port": 5000,

--- a/config/devnet/config.json
+++ b/config/devnet/config.json
@@ -1,7 +1,4 @@
 {
-	"ipc": {
-		"enabled": false
-	},
 	"networkVersion": "2.0",
 	"label": "devnet",
 	"genesisConfig": {
@@ -30,6 +27,11 @@
 	"logger": {
 		"fileLogLevel": "debug",
 		"consoleLogLevel": "info"
+	},
+	"rpc": {
+		"enable": false,
+		"mode": "ipc",
+		"port": 8080
 	},
 	"network": {
 		"port": 5000,

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -136,7 +136,7 @@ export default class StartCommand extends Command {
 				'Open port for the peer to peer incoming connections. Environment variable "LISK_PORT" can also be used.',
 			env: 'LISK_PORT',
 		}),
-		'enable-ipc': flagParser.boolean({
+		'api-ipc': flagParser.boolean({
 			description:
 				'Enable IPC communication. This will also load up plugins in child process and communicate over IPC.',
 			default: false,
@@ -145,7 +145,7 @@ export default class StartCommand extends Command {
 		'api-ws': flagParser.boolean({
 			description: 'Enable websocket communication for api-client.',
 			default: false,
-			exclusive: ['enable-ipc'],
+			exclusive: ['api-ipc'],
 		}),
 		'api-ws-port': flagParser.integer({
 			description: 'Port to be used for api-client websocket.',
@@ -313,8 +313,8 @@ export default class StartCommand extends Command {
 		config.label = pathConfig.label;
 		config.version = this.config.pjson.version;
 		// Inject other properties specified
-		if (flags['enable-ipc']) {
-			config.ipc = { enabled: flags['enable-ipc'] };
+		if (flags['api-ipc']) {
+			config.rpc = { enable: flags['api-ipc'], mode: 'ipc' };
 		}
 		if (flags['api-ws']) {
 			config.rpc = { enable: flags['api-ws'], mode: 'ws', port: flags['api-ws-port'] };

--- a/test/commands/start.spec.ts
+++ b/test/commands/start.spec.ts
@@ -110,11 +110,12 @@ describe('start', () => {
 		});
 	});
 
-	describe('when --enable-ipc is specified', () => {
+	describe('when --api-ipc is specified', () => {
 		it('should update the config value', async () => {
-			await StartCommand.run(['--enable-ipc'], config);
+			await StartCommand.run(['--api-ipc'], config);
 			const [, usedConfig] = (application.getApplication as jest.Mock).mock.calls[0];
-			expect(usedConfig.ipc.enabled).toBe(true);
+			expect(usedConfig.rpc.enable).toBe(true);
+			expect(usedConfig.rpc.mode).toBe('ipc');
 		});
 	});
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #410 

### How was it solved?

With breaking change of SDK https://github.com/LiskHQ/lisk-sdk/issues/5965, config is updated.
Also, name of the flag is now `api-ipc`

### How was it tested?

Start node with `--api-ipc` flag and see if `./bin/run node:info` works
