### PR TITLE
Fix to accept absolute path - Closes #418

### DIFF
--- a/src/commands/sdk/link.ts
+++ b/src/commands/sdk/link.ts
@@ -16,7 +16,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { Command } from '@oclif/command';
 import { symlink, pathExistsSync, removeSync } from 'fs-extra';
-import { join } from 'path';
+import { join, isAbsolute } from 'path';
 
 export default class LinkCommand extends Command {
 	static description = 'Symlink specific SDK folder during development.';
@@ -39,7 +39,8 @@ export default class LinkCommand extends Command {
 
 		const sdkLocalPath = join(__dirname, '../../../', 'node_modules', 'lisk-sdk');
 
-		const targetSDKFolderFromNodeModule = join('../', targetSDKFolder);
+		// If targetSDK folder is relative path, it should be relative from the node_module
+		const targetSDKFolderFromNodeModule = isAbsolute(targetSDKFolder) ? targetSDKFolder : join('../', targetSDKFolder);
 		removeSync(sdkLocalPath);
 		await symlink(targetSDKFolderFromNodeModule, sdkLocalPath);
 		this.log(`Linked '${targetSDKFolder as string}' to '${sdkLocalPath}'`);

--- a/src/commands/sdk/link.ts
+++ b/src/commands/sdk/link.ts
@@ -40,7 +40,9 @@ export default class LinkCommand extends Command {
 		const sdkLocalPath = join(__dirname, '../../../', 'node_modules', 'lisk-sdk');
 
 		// If targetSDK folder is relative path, it should be relative from the node_module
-		const targetSDKFolderFromNodeModule = isAbsolute(targetSDKFolder) ? targetSDKFolder : join('../', targetSDKFolder);
+		const targetSDKFolderFromNodeModule = isAbsolute(targetSDKFolder)
+			? targetSDKFolder
+			: join('../', targetSDKFolder);
 		removeSync(sdkLocalPath);
 		await symlink(targetSDKFolderFromNodeModule, sdkLocalPath);
 		this.log(`Linked '${targetSDKFolder as string}' to '${sdkLocalPath}'`);

--- a/test/commands/sdk/link.spec.ts
+++ b/test/commands/sdk/link.spec.ts
@@ -66,8 +66,25 @@ describe('sdk:link command', () => {
 			await LinkCommand.run([fakeSDKPath], config);
 			expect(fs.pathExistsSync).toHaveBeenCalledWith(fakeSDKPath);
 			expect(fs.removeSync).toHaveBeenCalledWith(targetSDKPath);
-			expect(fs.symlink).toHaveBeenCalledWith(join('../', fakeSDKPath), targetSDKPath);
+			expect(fs.symlink).toHaveBeenCalledWith(fakeSDKPath, targetSDKPath);
 			expect(stdout[0]).toContain(`Linked '/path/exists' to '${targetSDKPath}'`);
+		});
+	});
+
+	describe('sdk:link ../lisk-sdk/sdk', () => {
+		const fakeSDKPath = '../lisk-sdk/sdk';
+		const targetSDKPath = join(__dirname, '../../../', 'node_modules', 'lisk-sdk');
+
+		it('should call file system functions with correct parameters', async () => {
+			jest.spyOn(fs, 'pathExistsSync');
+			when(fs.pathExistsSync as jest.Mock)
+				.calledWith(fakeSDKPath)
+				.mockReturnValue(true);
+			await LinkCommand.run([fakeSDKPath], config);
+			expect(fs.pathExistsSync).toHaveBeenCalledWith(fakeSDKPath);
+			expect(fs.removeSync).toHaveBeenCalledWith(targetSDKPath);
+			expect(fs.symlink).toHaveBeenCalledWith(join('../', fakeSDKPath), targetSDKPath);
+			expect(stdout[0]).toContain(`Linked '../lisk-sdk/sdk' to '${targetSDKPath}'`);
 		});
 	});
 });


### PR DESCRIPTION
### What was the problem?

This PR resolves #418 

### How was it solved?

- Add check for absolute path for the symlink

### How was it tested?

```
./bin/run sdk:link ../lisk-sdk/sdk
 ./bin/run sdk:link /Users/path/to/lisk-sdk/sdk 
```
