### PR TITLE
Remove outdated flags - Closes #428 

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The following dependencies need to be installed in order to run applications cre
 
 | Dependencies | Version |
 | ------------ | ------- |
-| NodeJS       | 12.18.3 |
+| NodeJS       | 12.19.0 |
 
 You can find further details on installing these dependencies in our [pre-installation setup guide](https://lisk.io/documentation/lisk-core/setup/source#pre-install).
 Clone the Lisk Core repository using Git and initialize the modules.
@@ -57,7 +57,7 @@ $ npm install -g lisk-core
 $ lisk-core COMMAND
 running command...
 $ lisk-core (-v|--version|version)
-lisk-core/3.0.0-beta.2.1 darwin-x64 node-v12.18.3
+lisk-core/3.0.0-beta.2.5 darwin-x64 node-v12.19.0
 $ lisk-core --help [COMMAND]
 USAGE
   $ lisk-core COMMAND
@@ -68,7 +68,7 @@ USAGE
 
 <!-- commands -->
 
-# Command Topics
+## Command Topics
 
 - [`lisk-core account`](docs/commands/account.md) - Commands relating to Lisk Core accounts.
 - [`lisk-core block`](docs/commands/block.md) - Commands relating to Lisk Core blocks.
@@ -174,7 +174,7 @@ npm test
 In order to run a node for a local test, in a root folder of lisk-core, run below command.
 
 ```
-./bin/run start -n devnet --data-path ./devnet-data --port 3333 --enable-ipc --enable-http-api --http-api-port 3334 --enable-forger --forger-port 3335
+./bin/run start -n devnet --data-path ./devnet-data --port 3333 --api-ws --enable-http-api-plugin --http-api-plugin-port 3334 --enable-forger-plugin
 ```
 
 This command will start a lisk-core node using data path `./devent-data` with HTTPAPI and Forger Plugins.

--- a/docs/commands/account.md
+++ b/docs/commands/account.md
@@ -23,7 +23,7 @@ EXAMPLES
   account:create --count=3
 ```
 
-_See code: [dist/commands/account/create.ts](https://github.com/LiskHQ/lisk-core/blob/v3.0.0-beta.2.1/dist/commands/account/create.ts)_
+_See code: [dist/commands/account/create.ts](https://github.com/LiskHQ/lisk-core/blob/v3.0.0-beta.2.5/dist/commands/account/create.ts)_
 
 ## `lisk-core account:get ADDRESS`
 
@@ -46,7 +46,7 @@ EXAMPLE
   account:get ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815
 ```
 
-_See code: [dist/commands/account/get.ts](https://github.com/LiskHQ/lisk-core/blob/v3.0.0-beta.2.1/dist/commands/account/get.ts)_
+_See code: [dist/commands/account/get.ts](https://github.com/LiskHQ/lisk-core/blob/v3.0.0-beta.2.5/dist/commands/account/get.ts)_
 
 ## `lisk-core account:show`
 
@@ -67,7 +67,7 @@ EXAMPLE
   account:show
 ```
 
-_See code: [dist/commands/account/show.ts](https://github.com/LiskHQ/lisk-core/blob/v3.0.0-beta.2.1/dist/commands/account/show.ts)_
+_See code: [dist/commands/account/show.ts](https://github.com/LiskHQ/lisk-core/blob/v3.0.0-beta.2.5/dist/commands/account/show.ts)_
 
 ## `lisk-core account:validate ADDRESS`
 
@@ -84,4 +84,4 @@ EXAMPLE
   account:validate lskoaknq582o6fw7sp82bm2hnj7pzp47mpmbmux2g
 ```
 
-_See code: [dist/commands/account/validate.ts](https://github.com/LiskHQ/lisk-core/blob/v3.0.0-beta.2.1/dist/commands/account/validate.ts)_
+_See code: [dist/commands/account/validate.ts](https://github.com/LiskHQ/lisk-core/blob/v3.0.0-beta.2.5/dist/commands/account/validate.ts)_

--- a/docs/commands/block.md
+++ b/docs/commands/block.md
@@ -26,4 +26,4 @@ EXAMPLES
   block:get 2
 ```
 
-_See code: [dist/commands/block/get.ts](https://github.com/LiskHQ/lisk-core/blob/v3.0.0-beta.2.1/dist/commands/block/get.ts)_
+_See code: [dist/commands/block/get.ts](https://github.com/LiskHQ/lisk-core/blob/v3.0.0-beta.2.5/dist/commands/block/get.ts)_

--- a/docs/commands/blockchain.md
+++ b/docs/commands/blockchain.md
@@ -31,7 +31,7 @@ EXAMPLES
   download --url https://downloads.lisk.io/lisk/mainnet/blockchain.db.gz --output ./downloads
 ```
 
-_See code: [dist/commands/blockchain/download.ts](https://github.com/LiskHQ/lisk-core/blob/v3.0.0-beta.2.1/dist/commands/blockchain/download.ts)_
+_See code: [dist/commands/blockchain/download.ts](https://github.com/LiskHQ/lisk-core/blob/v3.0.0-beta.2.5/dist/commands/blockchain/download.ts)_
 
 ## `lisk-core blockchain:export`
 
@@ -52,7 +52,7 @@ EXAMPLES
   blockchain:export --data-path ./data --output ./my/path/
 ```
 
-_See code: [dist/commands/blockchain/export.ts](https://github.com/LiskHQ/lisk-core/blob/v3.0.0-beta.2.1/dist/commands/blockchain/export.ts)_
+_See code: [dist/commands/blockchain/export.ts](https://github.com/LiskHQ/lisk-core/blob/v3.0.0-beta.2.5/dist/commands/blockchain/export.ts)_
 
 ## `lisk-core blockchain:hash`
 
@@ -71,7 +71,7 @@ EXAMPLES
   blockchain:hash --data-path ./data
 ```
 
-_See code: [dist/commands/blockchain/hash.ts](https://github.com/LiskHQ/lisk-core/blob/v3.0.0-beta.2.1/dist/commands/blockchain/hash.ts)_
+_See code: [dist/commands/blockchain/hash.ts](https://github.com/LiskHQ/lisk-core/blob/v3.0.0-beta.2.5/dist/commands/blockchain/hash.ts)_
 
 ## `lisk-core blockchain:import FILEPATH`
 
@@ -95,7 +95,7 @@ EXAMPLES
   blockchain:import ./path/to/blockchain.db.gz --data-path ./lisk/
 ```
 
-_See code: [dist/commands/blockchain/import.ts](https://github.com/LiskHQ/lisk-core/blob/v3.0.0-beta.2.1/dist/commands/blockchain/import.ts)_
+_See code: [dist/commands/blockchain/import.ts](https://github.com/LiskHQ/lisk-core/blob/v3.0.0-beta.2.5/dist/commands/blockchain/import.ts)_
 
 ## `lisk-core blockchain:reset`
 
@@ -117,4 +117,4 @@ EXAMPLES
   blockchain:reset --yes
 ```
 
-_See code: [dist/commands/blockchain/reset.ts](https://github.com/LiskHQ/lisk-core/blob/v3.0.0-beta.2.1/dist/commands/blockchain/reset.ts)_
+_See code: [dist/commands/blockchain/reset.ts](https://github.com/LiskHQ/lisk-core/blob/v3.0.0-beta.2.5/dist/commands/blockchain/reset.ts)_

--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -25,4 +25,4 @@ EXAMPLES
   config:show --config ./custom-config.json --data-path ./data
 ```
 
-_See code: [dist/commands/config/show.ts](https://github.com/LiskHQ/lisk-core/blob/v3.0.0-beta.2.1/dist/commands/config/show.ts)_
+_See code: [dist/commands/config/show.ts](https://github.com/LiskHQ/lisk-core/blob/v3.0.0-beta.2.5/dist/commands/config/show.ts)_

--- a/docs/commands/forger-info.md
+++ b/docs/commands/forger-info.md
@@ -24,7 +24,7 @@ EXAMPLES
   forger-info:export --data-path ./data --output ./my/path/
 ```
 
-_See code: [dist/commands/forger-info/export.ts](https://github.com/LiskHQ/lisk-core/blob/v3.0.0-beta.2.1/dist/commands/forger-info/export.ts)_
+_See code: [dist/commands/forger-info/export.ts](https://github.com/LiskHQ/lisk-core/blob/v3.0.0-beta.2.5/dist/commands/forger-info/export.ts)_
 
 ## `lisk-core forger-info:import SOURCEPATH`
 
@@ -48,4 +48,4 @@ EXAMPLES
   forger-info:import --data-path ./data --force
 ```
 
-_See code: [dist/commands/forger-info/import.ts](https://github.com/LiskHQ/lisk-core/blob/v3.0.0-beta.2.1/dist/commands/forger-info/import.ts)_
+_See code: [dist/commands/forger-info/import.ts](https://github.com/LiskHQ/lisk-core/blob/v3.0.0-beta.2.5/dist/commands/forger-info/import.ts)_

--- a/docs/commands/forging.md
+++ b/docs/commands/forging.md
@@ -3,7 +3,7 @@
 Commands relating to Lisk Core forging.
 
 - [`lisk-core forging:disable ADDRESS`](#lisk-core-forgingdisable-address)
-- [`lisk-core forging:enable ADDRESS`](#lisk-core-forgingenable-address)
+- [`lisk-core forging:enable ADDRESS HEIGHT MAXHEIGHTPREVIOUSLYFORGED MAXHEIGHTPREVOTED`](#lisk-core-forgingenable-address-height-maxheightpreviouslyforged-maxheightprevoted)
 
 ## `lisk-core forging:disable ADDRESS`
 
@@ -25,26 +25,31 @@ OPTIONS
                              Examples:
                              - --password=pass:password123 (should only be used where security is not important)
 
+  --overwrite                Overwrites the forger info
+
   --pretty                   Prints JSON in pretty format rather than condensed.
 
 EXAMPLES
-  forging:disable address
-  forging:disable address --data-path ./data
-  forging:disable address --data-path ./data --password your_password
+  forging:disable ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815
+  forging:disable ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815 --data-path ./data
+  forging:disable ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815 --data-path ./data --password your_password
 ```
 
-_See code: [dist/commands/forging/disable.ts](https://github.com/LiskHQ/lisk-core/blob/v3.0.0-beta.2.1/dist/commands/forging/disable.ts)_
+_See code: [dist/commands/forging/disable.ts](https://github.com/LiskHQ/lisk-core/blob/v3.0.0-beta.2.5/dist/commands/forging/disable.ts)_
 
-## `lisk-core forging:enable ADDRESS`
+## `lisk-core forging:enable ADDRESS HEIGHT MAXHEIGHTPREVIOUSLYFORGED MAXHEIGHTPREVOTED`
 
 Enable forging for given delegate address.
 
 ```
 USAGE
-  $ lisk-core forging:enable ADDRESS
+  $ lisk-core forging:enable ADDRESS HEIGHT MAXHEIGHTPREVIOUSLYFORGED MAXHEIGHTPREVOTED
 
 ARGUMENTS
-  ADDRESS  Address of an account in a base32 format.
+  ADDRESS                    Address of an account in a base32 format.
+  HEIGHT                     Last forged block height.
+  MAXHEIGHTPREVIOUSLYFORGED  Delegates largest previously forged height.
+  MAXHEIGHTPREVOTED          Delegates largest prevoted height for a block.
 
 OPTIONS
   -d, --data-path=data-path  Directory path to specify where node data is stored. Environment variable "LISK_DATA_PATH"
@@ -55,12 +60,15 @@ OPTIONS
                              Examples:
                              - --password=pass:password123 (should only be used where security is not important)
 
+  --overwrite                Overwrites the forger info
+
   --pretty                   Prints JSON in pretty format rather than condensed.
 
 EXAMPLES
-  forging:enable address
-  forging:enable address --data-path ./data
-  forging:enable address --data-path ./data --password your_password
+  forging:enable ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815 100 100 10
+  forging:enable ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815 100 100 10 --overwrite
+  forging:enable ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815 100 100 10 --data-path ./data
+  forging:enable ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815 100 100 10 --data-path ./data --password your_password
 ```
 
-_See code: [dist/commands/forging/enable.ts](https://github.com/LiskHQ/lisk-core/blob/v3.0.0-beta.2.1/dist/commands/forging/enable.ts)_
+_See code: [dist/commands/forging/enable.ts](https://github.com/LiskHQ/lisk-core/blob/v3.0.0-beta.2.5/dist/commands/forging/enable.ts)_

--- a/docs/commands/hash-onion.md
+++ b/docs/commands/hash-onion.md
@@ -21,4 +21,4 @@ EXAMPLE
   hash-onion --count=1000000 --distance=2000
 ```
 
-_See code: [dist/commands/hash-onion.ts](https://github.com/LiskHQ/lisk-core/blob/v3.0.0-beta.2.1/dist/commands/hash-onion.ts)_
+_See code: [dist/commands/hash-onion.ts](https://github.com/LiskHQ/lisk-core/blob/v3.0.0-beta.2.5/dist/commands/hash-onion.ts)_

--- a/docs/commands/node.md
+++ b/docs/commands/node.md
@@ -23,4 +23,4 @@ EXAMPLES
   node:info --data-path ./lisk
 ```
 
-_See code: [dist/commands/node/info.ts](https://github.com/LiskHQ/lisk-core/blob/v3.0.0-beta.2.1/dist/commands/node/info.ts)_
+_See code: [dist/commands/node/info.ts](https://github.com/LiskHQ/lisk-core/blob/v3.0.0-beta.2.5/dist/commands/node/info.ts)_

--- a/docs/commands/passphrase.md
+++ b/docs/commands/passphrase.md
@@ -28,7 +28,7 @@ EXAMPLE
   4317a63bcf3d41ea74e83b&version=1"
 ```
 
-_See code: [dist/commands/passphrase/decrypt.ts](https://github.com/LiskHQ/lisk-core/blob/v3.0.0-beta.2.1/dist/commands/passphrase/decrypt.ts)_
+_See code: [dist/commands/passphrase/decrypt.ts](https://github.com/LiskHQ/lisk-core/blob/v3.0.0-beta.2.5/dist/commands/passphrase/decrypt.ts)_
 
 ## `lisk-core passphrase:encrypt`
 
@@ -57,4 +57,4 @@ EXAMPLE
   passphrase:encrypt
 ```
 
-_See code: [dist/commands/passphrase/encrypt.ts](https://github.com/LiskHQ/lisk-core/blob/v3.0.0-beta.2.1/dist/commands/passphrase/encrypt.ts)_
+_See code: [dist/commands/passphrase/encrypt.ts](https://github.com/LiskHQ/lisk-core/blob/v3.0.0-beta.2.5/dist/commands/passphrase/encrypt.ts)_

--- a/docs/commands/sdk.md
+++ b/docs/commands/sdk.md
@@ -19,4 +19,4 @@ EXAMPLE
   sdk:link /sdk/location/
 ```
 
-_See code: [dist/commands/sdk/link.ts](https://github.com/LiskHQ/lisk-core/blob/v3.0.0-beta.2.1/dist/commands/sdk/link.ts)_
+_See code: [dist/commands/sdk/link.ts](https://github.com/LiskHQ/lisk-core/blob/v3.0.0-beta.2.5/dist/commands/sdk/link.ts)_

--- a/docs/commands/start.md
+++ b/docs/commands/start.md
@@ -28,6 +28,13 @@ OPTIONS
   -p, --port=port                                        Open port for the peer to peer incoming connections.
                                                          Environment variable "LISK_PORT" can also be used.
 
+  --api-ipc                                              Enable IPC communication. This will also load up plugins in
+                                                         child process and communicate over IPC.
+
+  --api-ws                                               Enable websocket communication for api-client.
+
+  --api-ws-port=api-ws-port                              Port to be used for api-client websocket.
+
   --console-log=trace|debug|info|warn|error|fatal        Console log level. Environment variable
                                                          "LISK_CONSOLE_LOG_LEVEL" can also be used.
 
@@ -37,21 +44,24 @@ OPTIONS
   --enable-http-api-plugin                               Enable HTTP API Plugin. Environment variable
                                                          "LISK_ENABLE_HTTP_API_PLUGIN" can also be used.
 
-  --enable-ipc                                           Enable IPC communication. This will also load up plugins in
-                                                         child process and communicate over IPC.
+  --enable-monitor-plugin                                Enable Monitor Plugin. Environment variable
+                                                         "LISK_ENABLE_MONITOR_PLUGIN" can also be used.
 
-  --forger-plugin-port=forger-plugin-port                Port to be used for Forger Plugin. Environment variable
-                                                         "LISK_FORGER_PLUGIN_PORT" can also be used.
-
-  --forger-plugin-whitelist=forger-plugin-whitelist      List of IPs in comma separated value to allow the connection.
-                                                         Environment variable "LISK_FORGER_PLUGIN_WHITELIST" can also be
-                                                         used.
+  --enable-report-misbehavior-plugin                     Enable ReportMisbehavior Plugin. Environment variable
+                                                         "LISK_ENABLE_REPORT_MISBEHAVIOR_PLUGIN" can also be used.
 
   --http-api-plugin-port=http-api-plugin-port            Port to be used for HTTP API Plugin. Environment variable
                                                          "LISK_HTTP_API_PLUGIN_PORT" can also be used.
 
   --http-api-plugin-whitelist=http-api-plugin-whitelist  List of IPs in comma separated value to allow the connection.
                                                          Environment variable "LISK_HTTP_API_PLUGIN_WHITELIST" can also
+                                                         be used.
+
+  --monitor-plugin-port=monitor-plugin-port              Port to be used for Monitor Plugin. Environment variable
+                                                         "LISK_MONITOR_PLUGIN_PORT" can also be used.
+
+  --monitor-plugin-whitelist=monitor-plugin-whitelist    List of IPs in comma separated value to allow the connection.
+                                                         Environment variable "LISK_MONITOR_PLUGIN_WHITELIST" can also
                                                          be used.
 
   --overwrite-config                                     Overwrite network configs if they exist already
@@ -65,4 +75,4 @@ EXAMPLES
   start --network dev --data-path ./data --log debug
 ```
 
-_See code: [dist/commands/start.ts](https://github.com/LiskHQ/lisk-core/blob/v3.0.0-beta.2.1/dist/commands/start.ts)_
+_See code: [dist/commands/start.ts](https://github.com/LiskHQ/lisk-core/blob/v3.0.0-beta.2.5/dist/commands/start.ts)_

--- a/docs/commands/transaction.md
+++ b/docs/commands/transaction.md
@@ -60,7 +60,7 @@ EXAMPLES
   --asset='{"amount":100000000,"recipientAddress":"ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815","data":"send token"}'
 ```
 
-_See code: [dist/commands/transaction/create.ts](https://github.com/LiskHQ/lisk-core/blob/v3.0.0-beta.2.1/dist/commands/transaction/create.ts)_
+_See code: [dist/commands/transaction/create.ts](https://github.com/LiskHQ/lisk-core/blob/v3.0.0-beta.2.5/dist/commands/transaction/create.ts)_
 
 ## `lisk-core transaction:get ID`
 
@@ -83,7 +83,7 @@ EXAMPLE
   transaction:get eab06c6a22e88bca7150e0347a7d976acd070cb9284423e6eabecd657acc1263
 ```
 
-_See code: [dist/commands/transaction/get.ts](https://github.com/LiskHQ/lisk-core/blob/v3.0.0-beta.2.1/dist/commands/transaction/get.ts)_
+_See code: [dist/commands/transaction/get.ts](https://github.com/LiskHQ/lisk-core/blob/v3.0.0-beta.2.5/dist/commands/transaction/get.ts)_
 
 ## `lisk-core transaction:send TRANSACTION`
 
@@ -109,7 +109,7 @@ EXAMPLE
   a87bcfe6feaac46211c80472ad9297fd87727709f5d7e7b4134caf106b02
 ```
 
-_See code: [dist/commands/transaction/send.ts](https://github.com/LiskHQ/lisk-core/blob/v3.0.0-beta.2.1/dist/commands/transaction/send.ts)_
+_See code: [dist/commands/transaction/send.ts](https://github.com/LiskHQ/lisk-core/blob/v3.0.0-beta.2.5/dist/commands/transaction/send.ts)_
 
 ## `lisk-core transaction:sign TRANSACTION`
 
@@ -160,4 +160,4 @@ EXAMPLE
   f7a07bf5ec079d090630bb8ba347d5d82bf426cbffaaa8b5404f1190a7676c8bd406
 ```
 
-_See code: [dist/commands/transaction/sign.ts](https://github.com/LiskHQ/lisk-core/blob/v3.0.0-beta.2.1/dist/commands/transaction/sign.ts)_
+_See code: [dist/commands/transaction/sign.ts](https://github.com/LiskHQ/lisk-core/blob/v3.0.0-beta.2.5/dist/commands/transaction/sign.ts)_

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -17,12 +17,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { Command, flags as flagParser } from '@oclif/command';
 import * as fs from 'fs-extra';
-import {
-	ApplicationConfig,
-	HTTPAPIPlugin,
-	MonitorPlugin,
-	utils,
-} from 'lisk-sdk';
+import { ApplicationConfig, HTTPAPIPlugin, MonitorPlugin, utils } from 'lisk-sdk';
 import {
 	getDefaultPath,
 	splitPath,

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -19,10 +19,8 @@ import { Command, flags as flagParser } from '@oclif/command';
 import * as fs from 'fs-extra';
 import {
 	ApplicationConfig,
-	ForgerPlugin,
 	HTTPAPIPlugin,
 	MonitorPlugin,
-	ReportMisbehaviorPlugin,
 	utils,
 } from 'lisk-sdk';
 import {
@@ -60,19 +58,6 @@ const setPluginConfig = (config: ApplicationConfig, flags: Flags): void => {
 		config.plugins[HTTPAPIPlugin.alias] = config.plugins[HTTPAPIPlugin.alias] ?? {};
 		config.plugins[HTTPAPIPlugin.alias].whiteList = flags['http-api-plugin-whitelist'].split(',');
 	}
-	if (flags['forger-plugin-port'] !== undefined) {
-		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-		config.plugins[ForgerPlugin.alias] = config.plugins[ForgerPlugin.alias] ?? {};
-		config.plugins[ForgerPlugin.alias].port = flags['forger-plugin-port'];
-	}
-	if (
-		flags['forger-plugin-whitelist'] !== undefined &&
-		typeof flags['forger-plugin-whitelist'] === 'string'
-	) {
-		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-		config.plugins[ForgerPlugin.alias] = config.plugins[ForgerPlugin.alias] ?? {};
-		config.plugins[ForgerPlugin.alias].whiteList = flags['forger-plugin-whitelist'].split(',');
-	}
 	if (flags['monitor-plugin-port'] !== undefined) {
 		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
 		config.plugins[MonitorPlugin.alias] = config.plugins[MonitorPlugin.alias] ?? {};
@@ -85,23 +70,6 @@ const setPluginConfig = (config: ApplicationConfig, flags: Flags): void => {
 		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
 		config.plugins[MonitorPlugin.alias] = config.plugins[MonitorPlugin.alias] ?? {};
 		config.plugins[MonitorPlugin.alias].whiteList = flags['monitor-plugin-whitelist'].split(',');
-	}
-	if (flags['report-misbehavior-plugin-port'] !== undefined) {
-		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-		config.plugins[ReportMisbehaviorPlugin.alias] =
-			config.plugins[ReportMisbehaviorPlugin.alias] ?? {};
-		config.plugins[ReportMisbehaviorPlugin.alias].port = flags['report-misbehavior-plugin-port'];
-	}
-	if (
-		flags['report-misbehavior-plugin-whitelist'] !== undefined &&
-		typeof flags['report-misbehavior-plugin-whitelist'] === 'string'
-	) {
-		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-		config.plugins[ReportMisbehaviorPlugin.alias] =
-			config.plugins[ReportMisbehaviorPlugin.alias] ?? {};
-		config.plugins[ReportMisbehaviorPlugin.alias].whiteList = flags[
-			'report-misbehavior-plugin-whitelist'
-		].split(',');
 	}
 };
 
@@ -192,18 +160,6 @@ export default class StartCommand extends Command {
 			env: 'LISK_ENABLE_FORGER_PLUGIN',
 			default: false,
 		}),
-		'forger-plugin-port': flagParser.integer({
-			description:
-				'Port to be used for Forger Plugin. Environment variable "LISK_FORGER_PLUGIN_PORT" can also be used.',
-			env: 'LISK_FORGER_PLUGIN_PORT',
-			dependsOn: ['enable-forger-plugin'],
-		}),
-		'forger-plugin-whitelist': flagParser.string({
-			description:
-				'List of IPs in comma separated value to allow the connection. Environment variable "LISK_FORGER_PLUGIN_WHITELIST" can also be used.',
-			env: 'LISK_FORGER_PLUGIN_WHITELIST',
-			dependsOn: ['enable-forger-plugin'],
-		}),
 		'enable-monitor-plugin': flagParser.boolean({
 			description:
 				'Enable Monitor Plugin. Environment variable "LISK_ENABLE_MONITOR_PLUGIN" can also be used.',
@@ -227,18 +183,6 @@ export default class StartCommand extends Command {
 				'Enable ReportMisbehavior Plugin. Environment variable "LISK_ENABLE_REPORT_MISBEHAVIOR_PLUGIN" can also be used.',
 			env: 'LISK_ENABLE_MONITOR_PLUGIN',
 			default: false,
-		}),
-		'report-misbehavior-plugin-port': flagParser.integer({
-			description:
-				'Port to be used for ReportMisbehavior Plugin. Environment variable "LISK_REPORT_MISBEHAVIOR_PLUGIN_PORT" can also be used.',
-			env: 'LISK_REPORT_MISBEHAVIOR_PLUGIN_PORT',
-			dependsOn: ['enable-report-misbehavior-plugin'],
-		}),
-		'report-misbehavior-plugin-whitelist': flagParser.string({
-			description:
-				'List of IPs in comma separated value to allow the connection. Environment variable "LISK_REPORT_MISBEHAVIOR_PLUGIN_WHITELIST" can also be used.',
-			env: 'LISK_REPORT_MISBEHAVIOR_PLUGIN_WHITELIST',
-			dependsOn: ['enable-report-misbehavior-plugin'],
 		}),
 	};
 

--- a/test/commands/start.spec.ts
+++ b/test/commands/start.spec.ts
@@ -178,25 +178,6 @@ describe('start', () => {
 		});
 	});
 
-	describe('when custom port with --forger-plugin-port is specified along with --enable-forger-plugin', () => {
-		it('should update the config value', async () => {
-			await StartCommand.run(['--enable-forger-plugin', '--forger-plugin-port', '8888'], config);
-			const [, usedConfig] = (application.getApplication as jest.Mock).mock.calls[0];
-			expect(usedConfig.plugins.forger.port).toBe(8888);
-		});
-	});
-
-	describe('when custom white list with --forger-plugin-whitelist is specified along with --enable-forger-plugin', () => {
-		it('should update the config value', async () => {
-			await StartCommand.run(
-				['--enable-forger-plugin', '--forger-plugin-whitelist', '192.08.0.1:8888,192.08.0.2:8888'],
-				config,
-			);
-			const [, usedConfig] = (application.getApplication as jest.Mock).mock.calls[0];
-			expect(usedConfig.plugins.forger.whiteList).toEqual(['192.08.0.1:8888', '192.08.0.2:8888']);
-		});
-	});
-
 	describe('when --enable-monitor-plugin is specified', () => {
 		it('should pass this value to configuration', async () => {
 			await StartCommand.run(['--enable-monitor-plugin'], config);
@@ -233,35 +214,6 @@ describe('start', () => {
 			await StartCommand.run(['--enable-report-misbehavior-plugin'], config);
 			const [, , options] = (application.getApplication as jest.Mock).mock.calls[0];
 			expect(options.enableReportMisbehaviorPlugin).toBe(true);
-		});
-	});
-
-	describe('when custom port with --report-misbehavior-plugin-port is specified along with --enable-report-misbehavior-plugin', () => {
-		it('should update the config value', async () => {
-			await StartCommand.run(
-				['--enable-report-misbehavior-plugin', '--report-misbehavior-plugin-port', '8888'],
-				config,
-			);
-			const [, usedConfig] = (application.getApplication as jest.Mock).mock.calls[0];
-			expect(usedConfig.plugins.reportMisbehavior.port).toBe(8888);
-		});
-	});
-
-	describe('when custom white list with --report-misbehavior-plugin-whitelist is specified along with --enable-report-misbehavior-plugin', () => {
-		it('should update the config value', async () => {
-			await StartCommand.run(
-				[
-					'--enable-report-misbehavior-plugin',
-					'--report-misbehavior-plugin-whitelist',
-					'192.08.0.1:8888,192.08.0.2:8888',
-				],
-				config,
-			);
-			const [, usedConfig] = (application.getApplication as jest.Mock).mock.calls[0];
-			expect(usedConfig.plugins.reportMisbehavior.whiteList).toEqual([
-				'192.08.0.1:8888',
-				'192.08.0.2:8888',
-			]);
 		});
 	});
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #428 

### How was it solved?

- Remove outdated flags which were removed from sdk

### How was it tested?

It should be able to start node with report misbehavior and forger plugins with latest core