### PR TITLE
Add production flag on shrinkwrap - Closes #438

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"lint": "eslint --ext .js,.ts .",
 		"lint:fix": "eslint --fix --ext .js,.ts .",
 		"format": "prettier --write '**/*'",
-		"prepack": "oclif-dev manifest && npm shrinkwrap && oclif-dev readme --multi --dir=docs/commands",
+		"prepack": "oclif-dev manifest && npm shrinkwrap --production && oclif-dev readme --multi --dir=docs/commands",
 		"prebuild": "if test -d dist; then rm -r dist; fi; rm -f tsconfig.tsbuildinfo",
 		"build": "tsc",
 		"test": "jest",


### PR DESCRIPTION
### What was the problem?

This PR resolves #438 

### How was it solved?

Add production flag to avoid dev dependencies in srhinkwrap

### How was it tested?

`npm run prepack`
