### PR TITLE
Whitelist flag for HttpApi and Monitor plugin does not allow to set empty list #441

### DIFF
--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -51,7 +51,9 @@ const setPluginConfig = (config: ApplicationConfig, flags: Flags): void => {
 	) {
 		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
 		config.plugins[HTTPAPIPlugin.alias] = config.plugins[HTTPAPIPlugin.alias] ?? {};
-		config.plugins[HTTPAPIPlugin.alias].whiteList = flags['http-api-plugin-whitelist'].split(',');
+		config.plugins[HTTPAPIPlugin.alias].whiteList = flags['http-api-plugin-whitelist']
+			.split(',')
+			.filter(Boolean);
 	}
 	if (flags['monitor-plugin-port'] !== undefined) {
 		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
@@ -64,7 +66,9 @@ const setPluginConfig = (config: ApplicationConfig, flags: Flags): void => {
 	) {
 		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
 		config.plugins[MonitorPlugin.alias] = config.plugins[MonitorPlugin.alias] ?? {};
-		config.plugins[MonitorPlugin.alias].whiteList = flags['monitor-plugin-whitelist'].split(',');
+		config.plugins[MonitorPlugin.alias].whiteList = flags['monitor-plugin-whitelist']
+			.split(',')
+			.filter(Boolean);
 	}
 };
 

--- a/test/commands/start.spec.ts
+++ b/test/commands/start.spec.ts
@@ -170,6 +170,17 @@ describe('start', () => {
 		});
 	});
 
+	describe('when empty white list with --http-api-plugin-whitelist is specified along with --enable-http-api-plugin', () => {
+		it('should update the config value', async () => {
+			await StartCommand.run(
+				['--enable-http-api-plugin', '--http-api-plugin-whitelist', ''],
+				config,
+			);
+			const [, usedConfig] = (application.getApplication as jest.Mock).mock.calls[0];
+			expect(usedConfig.plugins.httpApi.whiteList).toEqual([]);
+		});
+	});
+
 	describe('when --enable-forger-plugin is specified', () => {
 		it('should pass this value to configuration', async () => {
 			await StartCommand.run(['--enable-forger-plugin'], config);
@@ -206,6 +217,14 @@ describe('start', () => {
 			);
 			const [, usedConfig] = (application.getApplication as jest.Mock).mock.calls[0];
 			expect(usedConfig.plugins.monitor.whiteList).toEqual(['192.08.0.1:8888', '192.08.0.2:8888']);
+		});
+	});
+
+	describe('when empty white list with --monitor-plugin-whitelist is specified along with --enable-monitor-plugin', () => {
+		it('should update the config value', async () => {
+			await StartCommand.run(['--enable-monitor-plugin', '--monitor-plugin-whitelist', ''], config);
+			const [, usedConfig] = (application.getApplication as jest.Mock).mock.calls[0];
+			expect(usedConfig.plugins.monitor.whiteList).toEqual([]);
 		});
 	});
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #441

### How was it solved?

- Updated parsing logic so empty string values can be treated as empty array

### How was it tested?

- Run unit tests
