### PR TITLE
Add daemons list on package.json - Closes #446

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
 		"lisk-core": "./bin/run"
 	},
 	"lisk": {
+		"daemons": ["start"],
 		"addressPrefix": "lsk"
 	},
 	"oclif": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
 		"lisk-core": "./bin/run"
 	},
 	"lisk": {
-		"daemons": ["start"],
+		"daemons": [
+			"start"
+		],
 		"addressPrefix": "lsk"
 	},
 	"oclif": {


### PR DESCRIPTION
### What was the problem?

This PR resolves #446 

### How was it solved?

To be able to dynamically create the daemon command list with https://github.com/LiskHQ/dev-cli/pull/3
added the list in the package json

### How was it tested?

`oclif-dev pack --targets=linux-x64` after installing the above PR
