### PR TITLE
Fix extention for the compressed database file - Closes #443

### DIFF
--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,2 +1,2 @@
 .env
-*blockchain.db.gz
+*blockchain..db.tar.gz

--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,2 +1,2 @@
 .env
-*blockchain..db.tar.gz
+*blockchain.db.tar.gz

--- a/docker/coldstart.sh
+++ b/docker/coldstart.sh
@@ -1,4 +1,4 @@
 #!/bin/sh -xe
 
 /home/lisk/node_modules/.bin/lisk-core blockchain:download --network=$1
-/home/lisk/node_modules/.bin/lisk-core blockchain:import --force blockchain.db.gz
+/home/lisk/node_modules/.bin/lisk-core blockchain:import --force blockchain.db.tar.gz

--- a/src/commands/blockchain/download.ts
+++ b/src/commands/blockchain/download.ts
@@ -25,7 +25,7 @@ export default class DownloadCommand extends Command {
 	static examples = [
 		'download',
 		'download --network betanet',
-		'download --url https://downloads.lisk.io/lisk/mainnet/blockchain.db.gz --output ./downloads',
+		'download --url https://downloads.lisk.io/lisk/mainnet/blockchain.db.tar.gz --output ./downloads',
 	];
 
 	static flags = {

--- a/src/commands/blockchain/import.ts
+++ b/src/commands/blockchain/import.ts
@@ -31,9 +31,9 @@ export default class ImportCommand extends Command {
 	];
 
 	static examples = [
-		'blockchain:import ./path/to/blockchain.db.gz',
-		'blockchain:import ./path/to/blockchain.db.gz --data-path ./lisk/',
-		'blockchain:import ./path/to/blockchain.db.gz --data-path ./lisk/ --force',
+		'blockchain:import ./path/to/blockchain.db.tar.gz',
+		'blockchain:import ./path/to/blockchain.db.tar.gz --data-path ./lisk/',
+		'blockchain:import ./path/to/blockchain.db.tar.gz --data-path ./lisk/ --force',
 	];
 
 	static flags = {

--- a/src/utils/commons.ts
+++ b/src/utils/commons.ts
@@ -20,7 +20,7 @@ export const liskSnapshotUrl = (url: string, network: NETWORK): string => {
 		return '';
 	}
 	if (url && url.search(RELEASE_URL) >= 0) {
-		return `${RELEASE_URL}/${network}/blockchain.db.gz`;
+		return `${RELEASE_URL}/${network}/blockchain.db.tar.gz`;
 	}
 	return url;
 };

--- a/test/commands/blockchain/download.spec.ts
+++ b/test/commands/blockchain/download.spec.ts
@@ -20,7 +20,7 @@ import DownloadCommand from '../../../src/commands/blockchain/download';
 import { getConfig } from '../../utils/config';
 
 describe('blockchain:download', () => {
-	const SNAPSHOT_URL = 'https://downloads.lisk.io/lisk/mainnet/blockchain.db.gz';
+	const SNAPSHOT_URL = 'https://downloads.lisk.io/lisk/mainnet/blockchain.db.tar.gz';
 	const dataPath = process.cwd();
 
 	let stdout: string[];

--- a/test/utils/download.spec.ts
+++ b/test/utils/download.spec.ts
@@ -18,7 +18,7 @@ import { EventEmitter } from 'events';
 import * as downloadUtil from '../../src/utils/download';
 
 describe('download utils', () => {
-	const url = 'https://downloads.lisk.io/lisk/betanet/blockchain.db.gz';
+	const url = 'https://downloads.lisk.io/lisk/betanet/blockchain.db.tar.gz';
 	const outDir = './tmp/cache/lisk-core';
 
 	describe('#download', () => {


### PR DESCRIPTION
### What was the problem?

This PR resolves #443 

### How was it solved?

- Update the extension to be tar.gz consistently

### How was it tested?
```
./bin/run blockchain:download -n betanet # check the URL
./bin/run ./bin/run blockchain:import --help  # check the description
```