### PR TITLE
Generate forging config for given passphrase, password and hash-onion parameters - Closes #434, #460, 461

### DIFF
--- a/src/commands/forging/config.ts
+++ b/src/commands/forging/config.ts
@@ -54,7 +54,14 @@ export default class ConfigCommand extends Command {
 
 	async run(): Promise<void> {
 		const {
-			flags: { count, distance, output, passphrase: passphraseSource, password: passwordSource, pretty },
+			flags: {
+				count,
+				distance,
+				output,
+				passphrase: passphraseSource,
+				password: passwordSource,
+				pretty,
+			},
 		} = this.parse(ConfigCommand);
 
 		if (distance <= 0 || !validator.isValidInteger(distance)) {

--- a/src/commands/forging/config.ts
+++ b/src/commands/forging/config.ts
@@ -25,7 +25,8 @@ export default class ConfigCommand extends Command {
 	static description = 'Generate delegate forging config for given passphrase and password.';
 
 	static examples = [
-		'forging:config, forging:config --password your_password',
+		'forging:config',
+		'forging:config --password your_password',
 		'forging:config --passphrase your_passphrase --password your_password --pretty',
 		'forging:config --count=1000000 --distance=2000 --output /tmp/forging_config.json',
 	];

--- a/src/commands/forging/config.ts
+++ b/src/commands/forging/config.ts
@@ -25,7 +25,8 @@ export default class ConfigCommand extends Command {
 	static description = 'Generate delegate forging config for given passphrase and password.';
 
 	static examples = [
-		'forging:config, forging:config --password your_password, forging:config --passphrase your_passphrase --password your_password',
+		'forging:config, forging:config --password your_password',
+		'forging:config --passphrase your_passphrase --password your_password --pretty',
 		'forging:config --count=1000000 --distance=2000 --output /tmp/forging_config.json',
 	];
 
@@ -46,11 +47,14 @@ export default class ConfigCommand extends Command {
 			char: 'o',
 			description: 'Output file path',
 		}),
+		pretty: flagParser.boolean({
+			description: 'Prints JSON in pretty format rather than condensed.',
+		}),
 	};
 
 	async run(): Promise<void> {
 		const {
-			flags: { count, distance, output, passphrase: passphraseSource, password: passwordSource },
+			flags: { count, distance, output, passphrase: passphraseSource, password: passwordSource, pretty },
 		} = this.parse(ConfigCommand);
 
 		if (distance <= 0 || !validator.isValidInteger(distance)) {
@@ -80,15 +84,12 @@ export default class ConfigCommand extends Command {
 		if (output) {
 			fs.writeJSONSync(output, { address, encryptedPassphrase, hashOnion });
 		} else {
-			this.printJSON({ address, encryptedPassphrase, hashOnion });
-		}
-	}
-
-	public printJSON(message?: object, pretty = false): void {
-		if (pretty) {
-			this.log(JSON.stringify(message, undefined, '  '));
-		} else {
-			this.log(JSON.stringify(message));
+			const message = { address, encryptedPassphrase, hashOnion };
+			if (pretty) {
+				this.log(JSON.stringify(message, undefined, '  '));
+			} else {
+				this.log(JSON.stringify(message));
+			}
 		}
 	}
 }

--- a/src/commands/forging/config.ts
+++ b/src/commands/forging/config.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+
+import { flags as flagParser, Command } from '@oclif/command';
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import { cryptography, validator } from 'lisk-sdk';
+import { encryptPassphrase } from '../../utils/commons';
+import { flags as commonFlags } from '../../utils/flags';
+import { getPassphraseFromPrompt, getPasswordFromPrompt } from '../../utils/reader';
+
+export default class ConfigCommand extends Command {
+	static description = 'Generate delegate forging config for given passphrase and password.';
+
+	static examples = [
+		'forging:config, forging:config --password your_password, forging:config --passphrase your_passphrase --password your_password',
+		'forging:config --count=1000000 --distance=2000 --output /tmp/forging_config.json',
+	];
+
+	static flags = {
+		password: flagParser.string({ ...commonFlags.password, required: true }),
+		passphrase: flagParser.string({ ...commonFlags.passphrase, required: true }),
+		count: flagParser.integer({
+			char: 'c',
+			description: 'Total number of hashes to produce',
+			default: 1000000,
+		}),
+		distance: flagParser.integer({
+			char: 'd',
+			description: 'Distance between each hashes',
+			default: 1000,
+		}),
+		output: flagParser.string({
+			char: 'o',
+			description: 'Output file path',
+		}),
+	};
+
+	async run(): Promise<void> {
+		const {
+			flags: { count, distance, output, passphrase: passphraseSource, password: passwordSource },
+		} = this.parse(ConfigCommand);
+
+		if (distance <= 0 || !validator.isValidInteger(distance)) {
+			throw new Error('Distance flag must be an integer and greater than 0.');
+		}
+
+		if (count <= 0 || !validator.isValidInteger(count)) {
+			throw new Error('Count flag must be an integer and greater than 0.');
+		}
+
+		if (output) {
+			const { dir } = path.parse(output);
+			fs.ensureDirSync(dir);
+		}
+
+		const seed = cryptography.generateHashOnionSeed();
+
+		const hashBuffers = cryptography.hashOnion(seed, count, distance);
+		const hashes = hashBuffers.map(buf => buf.toString('hex'));
+		const hashOnion = { count, distance, hashes };
+
+		const passphrase = passphraseSource ?? (await getPassphraseFromPrompt('passphrase', true));
+		const address = cryptography.getAddressFromPassphrase(passphrase).toString('hex');
+		const password = passwordSource ?? (await getPasswordFromPrompt('password', true));
+		const { encryptedPassphrase } = encryptPassphrase(passphrase, password, false);
+
+		if (output) {
+			fs.writeJSONSync(output, { address, encryptedPassphrase, hashOnion });
+		} else {
+			this.printJSON({ address, encryptedPassphrase, hashOnion });
+		}
+	}
+
+	public printJSON(message?: object, pretty = false): void {
+		if (pretty) {
+			this.log(JSON.stringify(message, undefined, '  '));
+		} else {
+			this.log(JSON.stringify(message));
+		}
+	}
+}

--- a/src/commands/forging/config.ts
+++ b/src/commands/forging/config.ts
@@ -88,11 +88,15 @@ export default class ConfigCommand extends Command {
 		const address = cryptography.getAddressFromPassphrase(passphrase).toString('hex');
 		const password = passwordSource ?? (await getPasswordFromPrompt('password', true));
 		const { encryptedPassphrase } = encryptPassphrase(passphrase, password, false);
+		const message = { address, encryptedPassphrase, hashOnion };
 
 		if (output) {
-			fs.writeJSONSync(output, { address, encryptedPassphrase, hashOnion });
+			if (pretty) {
+				fs.writeJSONSync(output, message, { spaces: ' ' });
+			} else {
+				fs.writeJSONSync(output, message);
+			}
 		} else {
-			const message = { address, encryptedPassphrase, hashOnion };
 			this.printJSON(message, pretty);
 		}
 	}

--- a/src/commands/forging/config.ts
+++ b/src/commands/forging/config.ts
@@ -31,8 +31,8 @@ export default class ConfigCommand extends Command {
 	];
 
 	static flags = {
-		password: flagParser.string({ ...commonFlags.password, required: true }),
-		passphrase: flagParser.string({ ...commonFlags.passphrase, required: true }),
+		password: flagParser.string({ ...commonFlags.password }),
+		passphrase: flagParser.string({ ...commonFlags.passphrase }),
 		count: flagParser.integer({
 			char: 'c',
 			description: 'Total number of hashes to produce',

--- a/src/commands/forging/config.ts
+++ b/src/commands/forging/config.ts
@@ -85,11 +85,15 @@ export default class ConfigCommand extends Command {
 			fs.writeJSONSync(output, { address, encryptedPassphrase, hashOnion });
 		} else {
 			const message = { address, encryptedPassphrase, hashOnion };
-			if (pretty) {
-				this.log(JSON.stringify(message, undefined, '  '));
-			} else {
-				this.log(JSON.stringify(message));
-			}
+			this.printJSON(message, pretty);
+		}
+	}
+
+	public printJSON(message?: object, pretty = false): void {
+		if (pretty) {
+			this.log(JSON.stringify(message, undefined, '  '));
+		} else {
+			this.log(JSON.stringify(message));
 		}
 	}
 }

--- a/src/commands/forging/status.ts
+++ b/src/commands/forging/status.ts
@@ -17,7 +17,7 @@ import BaseIPCCommand from '../../base_ipc';
 export default class StatusCommand extends BaseIPCCommand {
 	static description = 'Get forging information for the locally running node.';
 
-	static examples = ['forging:info', 'forging:info --data-path ./sample --pretty'];
+	static examples = ['forging:status', 'forging:status --data-path ./sample --pretty'];
 
 	static flags = {
 		...BaseIPCCommand.flags,

--- a/src/commands/hash-onion.ts
+++ b/src/commands/hash-onion.ts
@@ -22,7 +22,7 @@ export default class HashOnionCommand extends Command {
 	static description = 'Create hash onions to be used by the forger.';
 
 	static examples = [
-		'hash-onion --count=1000000 --distance=2000',
+		'hash-onion --count=1000000 --distance=2000 --pretty',
 		'hash-onion --count=1000000 --distance=2000 --output ~/my_onion.json',
 	];
 
@@ -41,12 +41,15 @@ export default class HashOnionCommand extends Command {
 			description: 'Distance between each hashes',
 			default: 1000,
 		}),
+		pretty: flagParser.boolean({
+			description: 'Prints JSON in pretty format rather than condensed.',
+		}),
 	};
 
 	// eslint-disable-next-line @typescript-eslint/require-await
 	async run(): Promise<void> {
 		const {
-			flags: { output, count, distance },
+			flags: { output, count, distance, pretty },
 		} = this.parse(HashOnionCommand);
 
 		if (distance <= 0 || !validator.isValidInteger(distance)) {
@@ -72,7 +75,7 @@ export default class HashOnionCommand extends Command {
 		if (output) {
 			fs.writeJSONSync(output, result);
 		} else {
-			this.printJSON(result);
+			this.printJSON(result, pretty);
 		}
 	}
 

--- a/src/commands/hash-onion.ts
+++ b/src/commands/hash-onion.ts
@@ -73,7 +73,11 @@ export default class HashOnionCommand extends Command {
 		const result = { count, distance, hashes };
 
 		if (output) {
-			fs.writeJSONSync(output, result);
+			if (pretty) {
+				fs.writeJSONSync(output, result, { spaces: ' ' });
+			} else {
+				fs.writeJSONSync(output, result);
+			}
 		} else {
 			this.printJSON(result, pretty);
 		}

--- a/src/commands/passphrase/decrypt.ts
+++ b/src/commands/passphrase/decrypt.ts
@@ -51,17 +51,20 @@ export default class DecryptCommand extends Command {
 
 	static flags = {
 		password: flagParser.string(commonFlags.password),
+		pretty: flagParser.boolean({
+			description: 'Prints JSON in pretty format rather than condensed.',
+		}),
 	};
 
 	async run(): Promise<void> {
 		const {
 			args,
-			flags: { password: passwordSource },
+			flags: { password: passwordSource, pretty },
 		} = this.parse(DecryptCommand);
 		const { encryptedPassphrase }: Args = args;
 		const password = passwordSource ?? (await getPasswordFromPrompt('password', true));
 		const result = processInputs(password, encryptedPassphrase as string);
-		this.printJSON(result);
+		this.printJSON(result, pretty);
 	}
 
 	public printJSON(message?: object, pretty = false): void {

--- a/src/commands/passphrase/encrypt.ts
+++ b/src/commands/passphrase/encrypt.ts
@@ -28,6 +28,7 @@ export default class EncryptCommand extends Command {
 		'passphrase:encrypt',
 		'passphrase:encrypt --passphrase your-passphrase',
 		'passphrase:encrypt --password your-password',
+		'passphrase:encrypt --password your-password --passphrase your-passphrase --pretty',
 		'passphrase:encrypt --output-public-key',
 	];
 
@@ -37,6 +38,9 @@ export default class EncryptCommand extends Command {
 		'output-public-key': flagParser.boolean({
 			description: outputPublicKeyOptionDescription,
 		}),
+		pretty: flagParser.boolean({
+			description: 'Prints JSON in pretty format rather than condensed.',
+		}),
 	};
 
 	async run(): Promise<void> {
@@ -45,6 +49,7 @@ export default class EncryptCommand extends Command {
 				passphrase: passphraseSource,
 				password: passwordSource,
 				'output-public-key': outputPublicKey,
+				pretty,
 			},
 		} = this.parse(EncryptCommand);
 
@@ -52,7 +57,7 @@ export default class EncryptCommand extends Command {
 		const password = passwordSource ?? (await getPasswordFromPrompt('password', true));
 		const result = encryptPassphrase(passphrase, password, outputPublicKey);
 
-		this.printJSON(result);
+		this.printJSON(result, pretty);
 	}
 
 	public printJSON(message?: object, pretty = false): void {

--- a/test/commands/forging/config.spec.ts
+++ b/test/commands/forging/config.spec.ts
@@ -20,135 +20,144 @@ import { getConfig } from '../../utils/config';
 import * as readerUtils from '../../../src/utils/reader';
 
 describe('forging:config command', () => {
-  const address = '67f7c759b8533acf4f25b6892dbda04323507b32';
-  const encryptedPassphraseString =
-    'salt=683425ca06c9ff88a5ab292bb5066dc5&cipherText=4ce151&iv=bfaeef79a466e370e210f3c6&tag=e84bf097b1ec5ae428dd7ed3b4cce522&version=1';
-  const defaultKeys = {
-    publicKey: Buffer.from(
-      '337600533a1f734c84b738d5f634c284a80ecc8b92bae4f30c1f22f8fd001e6a',
-      'hex',
-    ),
-  };
-  const encryptedPassphraseObject = {
-    salt: 'salt',
-    cipherText: 'cipherText',
-    iv: 'iv',
-    tag: 'tag',
-    version: '1',
-  };
-  const defaultInputs = {
-    passphrase: 'enemy pill squeeze gold spoil aisle awake thumb congress false box wagon',
-    password: 'LbYpLpV9Wpec6ux8',
-  };
-  const consoleWarnSpy = jest.spyOn(console, 'warn');
+	const address = '67f7c759b8533acf4f25b6892dbda04323507b32';
+	const encryptedPassphraseString =
+		'salt=683425ca06c9ff88a5ab292bb5066dc5&cipherText=4ce151&iv=bfaeef79a466e370e210f3c6&tag=e84bf097b1ec5ae428dd7ed3b4cce522&version=1';
+	const defaultKeys = {
+		publicKey: Buffer.from(
+			'337600533a1f734c84b738d5f634c284a80ecc8b92bae4f30c1f22f8fd001e6a',
+			'hex',
+		),
+	};
+	const encryptedPassphraseObject = {
+		salt: 'salt',
+		cipherText: 'cipherText',
+		iv: 'iv',
+		tag: 'tag',
+		version: '1',
+	};
+	const defaultInputs = {
+		passphrase: 'enemy pill squeeze gold spoil aisle awake thumb congress false box wagon',
+		password: 'LbYpLpV9Wpec6ux8',
+	};
+	const consoleWarnSpy = jest.spyOn(console, 'warn');
 
-  let stdout: string[];
-  let stderr: string[];
-  let config: Config.IConfig;
+	let stdout: string[];
+	let stderr: string[];
+	let config: Config.IConfig;
 
+	beforeEach(async () => {
+		stdout = [];
+		stderr = [];
+		config = await getConfig();
+		jest.spyOn(process.stdout, 'write').mockImplementation(val => stdout.push(val as string) > -1);
+		jest.spyOn(process.stderr, 'write').mockImplementation(val => stderr.push(val as string) > -1);
+		jest.spyOn(ConfigCommand.prototype, 'printJSON').mockReturnValue();
+		jest.spyOn(cryptography, 'getKeys').mockReturnValue(defaultKeys as never);
+		jest.spyOn(fs, 'ensureDirSync').mockReturnValue();
+		jest.spyOn(fs, 'writeJSONSync').mockReturnValue();
+		jest
+			.spyOn(cryptography, 'encryptPassphraseWithPassword')
+			.mockReturnValue(encryptedPassphraseObject);
+		jest
+			.spyOn(cryptography, 'stringifyEncryptedPassphrase')
+			.mockReturnValue(encryptedPassphraseString);
+		jest
+			.spyOn(readerUtils, 'getPassphraseFromPrompt')
+			// eslint-disable-next-line @typescript-eslint/require-await
+			.mockImplementation(async (name?: string) => {
+				if (name === 'passphrase') {
+					return defaultInputs.passphrase;
+				}
+				return '';
+			});
+		jest
+			.spyOn(readerUtils, 'getPasswordFromPrompt')
+			// eslint-disable-next-line @typescript-eslint/require-await
+			.mockImplementation(async (name?: string) => {
+				if (name === 'password') {
+					return defaultInputs.password;
+				}
+				return '';
+			});
+	});
 
-  beforeEach(async () => {
-    stdout = [];
-    stderr = [];
-    config = await getConfig();
-    jest.spyOn(process.stdout, 'write').mockImplementation(val => stdout.push(val as string) > -1);
-    jest.spyOn(process.stderr, 'write').mockImplementation(val => stderr.push(val as string) > -1);
-    jest.spyOn(ConfigCommand.prototype, 'printJSON').mockReturnValue();
-    jest.spyOn(cryptography, 'getKeys').mockReturnValue(defaultKeys as never);
-    jest.spyOn(fs, 'ensureDirSync').mockReturnValue();
-    jest.spyOn(fs, 'writeJSONSync').mockReturnValue();
-    jest
-      .spyOn(cryptography, 'encryptPassphraseWithPassword')
-      .mockReturnValue(encryptedPassphraseObject);
-    jest
-      .spyOn(cryptography, 'stringifyEncryptedPassphrase')
-      .mockReturnValue(encryptedPassphraseString);
-    jest
-      .spyOn(readerUtils, 'getPassphraseFromPrompt')
-      // eslint-disable-next-line @typescript-eslint/require-await
-      .mockImplementation(async (name?: string) => {
-        if (name === 'passphrase') {
-          return defaultInputs.passphrase;
-        }
-        return '';
-      });
-    jest
-      .spyOn(readerUtils, 'getPasswordFromPrompt')
-      // eslint-disable-next-line @typescript-eslint/require-await
-      .mockImplementation(async (name?: string) => {
-        if (name === 'password') {
-          return defaultInputs.password;
-        }
-        return '';
-      });
+	describe('forging:config', () => {
+		describe('generate forging config and print', () => {
+			it('should encrypt passphrase and with default hash-onions', async () => {
+				await ConfigCommand.run(['--count=2', '--distance=1', '--pretty'], config);
+				expect(cryptography.encryptPassphraseWithPassword).toHaveBeenCalledWith(
+					defaultInputs.passphrase,
+					defaultInputs.password,
+				);
+				expect(cryptography.stringifyEncryptedPassphrase).toHaveBeenCalledWith(
+					encryptedPassphraseObject,
+				);
+				expect(readerUtils.getPassphraseFromPrompt).toHaveBeenCalledWith('passphrase', true);
+				expect(readerUtils.getPasswordFromPrompt).toHaveBeenCalledWith('password', true);
 
-  });
+				expect(ConfigCommand.prototype.printJSON).toHaveBeenCalledWith(
+					{
+						address,
+						encryptedPassphrase: encryptedPassphraseString,
+						hashOnion: {
+							count: 2,
+							distance: 1,
+							hashes: expect.anything(),
+						},
+					},
+					true,
+				);
+				expect(consoleWarnSpy).toHaveBeenCalledTimes(0);
+			});
 
-  describe('forging:config', () => {
-    describe('generate forging config and print', () => {
-      it('should encrypt passphrase and with default hash-onions', async () => {
-        await ConfigCommand.run(['--count=2', '--distance=1', '--pretty',], config);
-        expect(cryptography.encryptPassphraseWithPassword).toHaveBeenCalledWith(
-          defaultInputs.passphrase,
-          defaultInputs.password,
-        );
-        expect(cryptography.stringifyEncryptedPassphrase).toHaveBeenCalledWith(
-          encryptedPassphraseObject,
-        );
-        expect(readerUtils.getPassphraseFromPrompt).toHaveBeenCalledWith('passphrase', true);
-        expect(readerUtils.getPasswordFromPrompt).toHaveBeenCalledWith('password', true);
+			it('should encrypt passphrase from passphrase and password flags', async () => {
+				await ConfigCommand.run(
+					[
+						'--passphrase=enemy pill squeeze gold spoil aisle awake thumb congress false box wagon',
+						'--password=LbYpLpV9Wpec6ux8',
+						'--count=2',
+						'--distance=1',
+						'--pretty',
+					],
+					config,
+				);
+				expect(cryptography.encryptPassphraseWithPassword).toHaveBeenCalledWith(
+					defaultInputs.passphrase,
+					defaultInputs.password,
+				);
+				expect(cryptography.stringifyEncryptedPassphrase).toHaveBeenCalledWith(
+					encryptedPassphraseObject,
+				);
+				expect(readerUtils.getPassphraseFromPrompt).not.toHaveBeenCalledWith('passphrase', true);
+				expect(readerUtils.getPasswordFromPrompt).not.toHaveBeenCalledWith('password', true);
+				expect(ConfigCommand.prototype.printJSON).toHaveBeenCalledWith(
+					{
+						address,
+						encryptedPassphrase: encryptedPassphraseString,
+						hashOnion: {
+							count: 2,
+							distance: 1,
+							hashes: expect.anything(),
+						},
+					},
+					true,
+				);
+			});
+		});
 
-        expect(ConfigCommand.prototype.printJSON).toHaveBeenCalledWith({
-          address,
-          encryptedPassphrase: encryptedPassphraseString,
-          hashOnion: {
-            count: 2,
-            distance: 1,
-            hashes: expect.anything(),
-          }
-        }, true);
-        expect(consoleWarnSpy).toHaveBeenCalledTimes(0);
-      });
-
-      it('should encrypt passphrase from passphrase and password flags', async () => {
-        await ConfigCommand.run(
-          [
-            '--passphrase=enemy pill squeeze gold spoil aisle awake thumb congress false box wagon',
-            '--password=LbYpLpV9Wpec6ux8',
-            '--count=2', '--distance=1', '--pretty',
-          ],
-          config,
-        );
-        expect(cryptography.encryptPassphraseWithPassword).toHaveBeenCalledWith(
-          defaultInputs.passphrase,
-          defaultInputs.password,
-        );
-        expect(cryptography.stringifyEncryptedPassphrase).toHaveBeenCalledWith(
-          encryptedPassphraseObject,
-        );
-        expect(readerUtils.getPassphraseFromPrompt).not.toHaveBeenCalledWith('passphrase', true);
-        expect(readerUtils.getPasswordFromPrompt).not.toHaveBeenCalledWith('password', true);
-        expect(ConfigCommand.prototype.printJSON).toHaveBeenCalledWith({
-          address,
-          encryptedPassphrase: encryptedPassphraseString,
-          hashOnion: {
-            count: 2,
-            distance: 1,
-            hashes: expect.anything(),
-          }
-        }, true);
-      });
-    });
-
-    describe('generate forging config and save', () => {
-      it('should write forging config to file', async () => {
-        await ConfigCommand.run(
-          ['--count=2', '--distance=1', '--output=/tmp/forging_config.json'],
-          config,
-        );
-        expect(fs.ensureDirSync).toHaveBeenCalledWith('/tmp');
-        expect(fs.writeJSONSync).toHaveBeenCalledWith('/tmp/forging_config.json', expect.anything());
-      });
-    });
-  });
+		describe('generate forging config and save', () => {
+			it('should write forging config to file', async () => {
+				await ConfigCommand.run(
+					['--count=2', '--distance=1', '--output=/tmp/forging_config.json'],
+					config,
+				);
+				expect(fs.ensureDirSync).toHaveBeenCalledWith('/tmp');
+				expect(fs.writeJSONSync).toHaveBeenCalledWith(
+					'/tmp/forging_config.json',
+					expect.anything(),
+				);
+			});
+		});
+	});
 });

--- a/test/commands/forging/config.spec.ts
+++ b/test/commands/forging/config.spec.ts
@@ -1,0 +1,154 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import * as fs from 'fs-extra';
+import * as Config from '@oclif/config';
+import { cryptography } from 'lisk-sdk';
+import ConfigCommand from '../../../src/commands/forging/config';
+import { getConfig } from '../../utils/config';
+import * as readerUtils from '../../../src/utils/reader';
+
+describe('forging:config command', () => {
+  const address = '67f7c759b8533acf4f25b6892dbda04323507b32';
+  const encryptedPassphraseString =
+    'salt=683425ca06c9ff88a5ab292bb5066dc5&cipherText=4ce151&iv=bfaeef79a466e370e210f3c6&tag=e84bf097b1ec5ae428dd7ed3b4cce522&version=1';
+  const defaultKeys = {
+    publicKey: Buffer.from(
+      '337600533a1f734c84b738d5f634c284a80ecc8b92bae4f30c1f22f8fd001e6a',
+      'hex',
+    ),
+  };
+  const encryptedPassphraseObject = {
+    salt: 'salt',
+    cipherText: 'cipherText',
+    iv: 'iv',
+    tag: 'tag',
+    version: '1',
+  };
+  const defaultInputs = {
+    passphrase: 'enemy pill squeeze gold spoil aisle awake thumb congress false box wagon',
+    password: 'LbYpLpV9Wpec6ux8',
+  };
+  const consoleWarnSpy = jest.spyOn(console, 'warn');
+
+  let stdout: string[];
+  let stderr: string[];
+  let config: Config.IConfig;
+
+
+  beforeEach(async () => {
+    stdout = [];
+    stderr = [];
+    config = await getConfig();
+    jest.spyOn(process.stdout, 'write').mockImplementation(val => stdout.push(val as string) > -1);
+    jest.spyOn(process.stderr, 'write').mockImplementation(val => stderr.push(val as string) > -1);
+    jest.spyOn(ConfigCommand.prototype, 'printJSON').mockReturnValue();
+    jest.spyOn(cryptography, 'getKeys').mockReturnValue(defaultKeys as never);
+    jest.spyOn(fs, 'ensureDirSync').mockReturnValue();
+    jest.spyOn(fs, 'writeJSONSync').mockReturnValue();
+    jest
+      .spyOn(cryptography, 'encryptPassphraseWithPassword')
+      .mockReturnValue(encryptedPassphraseObject);
+    jest
+      .spyOn(cryptography, 'stringifyEncryptedPassphrase')
+      .mockReturnValue(encryptedPassphraseString);
+    jest
+      .spyOn(readerUtils, 'getPassphraseFromPrompt')
+      // eslint-disable-next-line @typescript-eslint/require-await
+      .mockImplementation(async (name?: string) => {
+        if (name === 'passphrase') {
+          return defaultInputs.passphrase;
+        }
+        return '';
+      });
+    jest
+      .spyOn(readerUtils, 'getPasswordFromPrompt')
+      // eslint-disable-next-line @typescript-eslint/require-await
+      .mockImplementation(async (name?: string) => {
+        if (name === 'password') {
+          return defaultInputs.password;
+        }
+        return '';
+      });
+
+  });
+
+  describe('forging:config', () => {
+    describe('generate forging config and print', () => {
+      it('should encrypt passphrase and with default hash-onions', async () => {
+        await ConfigCommand.run(['--count=2', '--distance=1', '--pretty',], config);
+        expect(cryptography.encryptPassphraseWithPassword).toHaveBeenCalledWith(
+          defaultInputs.passphrase,
+          defaultInputs.password,
+        );
+        expect(cryptography.stringifyEncryptedPassphrase).toHaveBeenCalledWith(
+          encryptedPassphraseObject,
+        );
+        expect(readerUtils.getPassphraseFromPrompt).toHaveBeenCalledWith('passphrase', true);
+        expect(readerUtils.getPasswordFromPrompt).toHaveBeenCalledWith('password', true);
+
+        expect(ConfigCommand.prototype.printJSON).toHaveBeenCalledWith({
+          address,
+          encryptedPassphrase: encryptedPassphraseString,
+          hashOnion: {
+            count: 2,
+            distance: 1,
+            hashes: expect.anything(),
+          }
+        }, true);
+        expect(consoleWarnSpy).toHaveBeenCalledTimes(0);
+      });
+
+      it('should encrypt passphrase from passphrase and password flags', async () => {
+        await ConfigCommand.run(
+          [
+            '--passphrase=enemy pill squeeze gold spoil aisle awake thumb congress false box wagon',
+            '--password=LbYpLpV9Wpec6ux8',
+            '--count=2', '--distance=1', '--pretty',
+          ],
+          config,
+        );
+        expect(cryptography.encryptPassphraseWithPassword).toHaveBeenCalledWith(
+          defaultInputs.passphrase,
+          defaultInputs.password,
+        );
+        expect(cryptography.stringifyEncryptedPassphrase).toHaveBeenCalledWith(
+          encryptedPassphraseObject,
+        );
+        expect(readerUtils.getPassphraseFromPrompt).not.toHaveBeenCalledWith('passphrase', true);
+        expect(readerUtils.getPasswordFromPrompt).not.toHaveBeenCalledWith('password', true);
+        expect(ConfigCommand.prototype.printJSON).toHaveBeenCalledWith({
+          address,
+          encryptedPassphrase: encryptedPassphraseString,
+          hashOnion: {
+            count: 2,
+            distance: 1,
+            hashes: expect.anything(),
+          }
+        }, true);
+      });
+    });
+
+    describe('generate forging config and save', () => {
+      it('should write forging config to file', async () => {
+        await ConfigCommand.run(
+          ['--count=2', '--distance=1', '--output=/tmp/forging_config.json'],
+          config,
+        );
+        expect(fs.ensureDirSync).toHaveBeenCalledWith('/tmp');
+        expect(fs.writeJSONSync).toHaveBeenCalledWith('/tmp/forging_config.json', expect.anything());
+      });
+    });
+  });
+});

--- a/test/commands/forging/config.spec.ts
+++ b/test/commands/forging/config.spec.ts
@@ -158,6 +158,19 @@ describe('forging:config command', () => {
 					expect.anything(),
 				);
 			});
+
+			it('should write forging config to file in pretty format', async () => {
+				await ConfigCommand.run(
+					['--count=2', '--distance=1', '--pretty', '--output=/tmp/forging_config.json'],
+					config,
+				);
+				expect(fs.ensureDirSync).toHaveBeenCalledWith('/tmp');
+				expect(fs.writeJSONSync).toHaveBeenCalledWith(
+					'/tmp/forging_config.json',
+					expect.anything(),
+					{ spaces: ' ' },
+				);
+			});
 		});
 	});
 });

--- a/test/commands/hash-onion.spec.ts
+++ b/test/commands/hash-onion.spec.ts
@@ -59,6 +59,17 @@ describe('hash-onion command', () => {
 			expect(fs.ensureDirSync).toHaveBeenCalledWith('./test');
 			expect(fs.writeJSONSync).toHaveBeenCalledWith('./test/sample.json', expect.anything());
 		});
+
+		it('should write to file in pretty format', async () => {
+			await HashOnionCommand.run(
+				['--count=1000', '--distance=200', '--pretty', '--output=./test/sample.json'],
+				config,
+			);
+			expect(fs.ensureDirSync).toHaveBeenCalledWith('./test');
+			expect(fs.writeJSONSync).toHaveBeenCalledWith('./test/sample.json', expect.anything(), {
+				spaces: ' ',
+			});
+		});
 	});
 
 	describe('hash-onion --count=777 --distance=200', () => {

--- a/test/commands/passphrase/decrypt.spec.ts
+++ b/test/commands/passphrase/decrypt.spec.ts
@@ -79,9 +79,12 @@ describe('passphrase:decrypt', () => {
 				encryptedPassphraseObject,
 				defaultInputs,
 			);
-			expect(DecryptCommand.prototype.printJSON).toHaveBeenCalledWith({
-				passphrase,
-			}, undefined);
+			expect(DecryptCommand.prototype.printJSON).toHaveBeenCalledWith(
+				{
+					passphrase,
+				},
+				undefined,
+			);
 		});
 	});
 });

--- a/test/commands/passphrase/decrypt.spec.ts
+++ b/test/commands/passphrase/decrypt.spec.ts
@@ -64,7 +64,7 @@ describe('passphrase:decrypt', () => {
 				encryptedPassphraseObject,
 				defaultInputs,
 			);
-			expect(DecryptCommand.prototype.printJSON).toHaveBeenCalledWith({ passphrase });
+			expect(DecryptCommand.prototype.printJSON).toHaveBeenCalledWith({ passphrase }, undefined);
 		});
 	});
 
@@ -81,7 +81,7 @@ describe('passphrase:decrypt', () => {
 			);
 			expect(DecryptCommand.prototype.printJSON).toHaveBeenCalledWith({
 				passphrase,
-			});
+			}, undefined);
 		});
 	});
 });

--- a/test/commands/passphrase/encrypt.spec.ts
+++ b/test/commands/passphrase/encrypt.spec.ts
@@ -91,9 +91,12 @@ describe('passphrase:encrypt', () => {
 			expect(readerUtils.getPassphraseFromPrompt).toHaveBeenCalledWith('passphrase', true);
 			expect(readerUtils.getPasswordFromPrompt).toHaveBeenCalledWith('password', true);
 
-			expect(EncryptCommand.prototype.printJSON).toHaveBeenCalledWith({
-				encryptedPassphrase: encryptedPassphraseString,
-			}, undefined);
+			expect(EncryptCommand.prototype.printJSON).toHaveBeenCalledWith(
+				{
+					encryptedPassphrase: encryptedPassphraseString,
+				},
+				undefined,
+			);
 			expect(consoleWarnSpy).toHaveBeenCalledTimes(0);
 		});
 	});
@@ -110,10 +113,13 @@ describe('passphrase:encrypt', () => {
 			);
 			expect(readerUtils.getPassphraseFromPrompt).toHaveBeenCalledWith('passphrase', true);
 			expect(readerUtils.getPasswordFromPrompt).toHaveBeenCalledWith('password', true);
-			expect(EncryptCommand.prototype.printJSON).toHaveBeenCalledWith({
-				encryptedPassphrase: encryptedPassphraseString,
-				publicKey: defaultKeys.publicKey.toString('hex'),
-			}, undefined);
+			expect(EncryptCommand.prototype.printJSON).toHaveBeenCalledWith(
+				{
+					encryptedPassphrase: encryptedPassphraseString,
+					publicKey: defaultKeys.publicKey.toString('hex'),
+				},
+				undefined,
+			);
 		});
 	});
 
@@ -132,9 +138,12 @@ describe('passphrase:encrypt', () => {
 			);
 			expect(readerUtils.getPassphraseFromPrompt).not.toHaveBeenCalledWith('passphrase', true);
 			expect(readerUtils.getPasswordFromPrompt).toHaveBeenCalledWith('password', true);
-			expect(EncryptCommand.prototype.printJSON).toHaveBeenCalledWith({
-				encryptedPassphrase: encryptedPassphraseString,
-			}, undefined);
+			expect(EncryptCommand.prototype.printJSON).toHaveBeenCalledWith(
+				{
+					encryptedPassphrase: encryptedPassphraseString,
+				},
+				undefined,
+			);
 		});
 	});
 
@@ -156,9 +165,12 @@ describe('passphrase:encrypt', () => {
 			);
 			expect(readerUtils.getPassphraseFromPrompt).not.toHaveBeenCalledWith('passphrase', true);
 			expect(readerUtils.getPasswordFromPrompt).not.toHaveBeenCalledWith('password', true);
-			expect(EncryptCommand.prototype.printJSON).toHaveBeenCalledWith({
-				encryptedPassphrase: encryptedPassphraseString,
-			}, undefined);
+			expect(EncryptCommand.prototype.printJSON).toHaveBeenCalledWith(
+				{
+					encryptedPassphrase: encryptedPassphraseString,
+				},
+				undefined,
+			);
 		});
 	});
 });

--- a/test/commands/passphrase/encrypt.spec.ts
+++ b/test/commands/passphrase/encrypt.spec.ts
@@ -93,7 +93,7 @@ describe('passphrase:encrypt', () => {
 
 			expect(EncryptCommand.prototype.printJSON).toHaveBeenCalledWith({
 				encryptedPassphrase: encryptedPassphraseString,
-			});
+			}, undefined);
 			expect(consoleWarnSpy).toHaveBeenCalledTimes(0);
 		});
 	});
@@ -113,7 +113,7 @@ describe('passphrase:encrypt', () => {
 			expect(EncryptCommand.prototype.printJSON).toHaveBeenCalledWith({
 				encryptedPassphrase: encryptedPassphraseString,
 				publicKey: defaultKeys.publicKey.toString('hex'),
-			});
+			}, undefined);
 		});
 	});
 
@@ -134,7 +134,7 @@ describe('passphrase:encrypt', () => {
 			expect(readerUtils.getPasswordFromPrompt).toHaveBeenCalledWith('password', true);
 			expect(EncryptCommand.prototype.printJSON).toHaveBeenCalledWith({
 				encryptedPassphrase: encryptedPassphraseString,
-			});
+			}, undefined);
 		});
 	});
 
@@ -158,7 +158,7 @@ describe('passphrase:encrypt', () => {
 			expect(readerUtils.getPasswordFromPrompt).not.toHaveBeenCalledWith('password', true);
 			expect(EncryptCommand.prototype.printJSON).toHaveBeenCalledWith({
 				encryptedPassphrase: encryptedPassphraseString,
-			});
+			}, undefined);
 		});
 	});
 });


### PR DESCRIPTION
### What was the problem?

This PR resolves #434 

### How was it solved?

- This command enables delegates to generate forging delegate config with
address, hashOnion and encryptedPassphrase details for given password and passphrase

### How was it tested?

<!--- Please describe how you tested your changes -->
