### PR TITLE
Update download commands to use snapshot - Closes #481

### DIFF
--- a/docs/commands/blockchain.md
+++ b/docs/commands/blockchain.md
@@ -28,7 +28,7 @@ OPTIONS
 EXAMPLES
   download
   download --network betanet
-  download --url https://downloads.lisk.io/lisk/mainnet/blockchain.db.gz --output ./downloads
+  download --url https://snapshots.lisk.io/mainnet/blockchain.db.gz --output ./downloads
 ```
 
 _See code: [dist/commands/blockchain/download.ts](https://github.com/LiskHQ/lisk-core/blob/v3.0.0-beta.2.5/dist/commands/blockchain/download.ts)_

--- a/src/commands/blockchain/download.ts
+++ b/src/commands/blockchain/download.ts
@@ -25,7 +25,7 @@ export default class DownloadCommand extends Command {
 	static examples = [
 		'download',
 		'download --network betanet',
-		'download --url https://snapshots.lisk.io/lisk/mainnet/blockchain.db.tar.gz --output ./downloads',
+		'download --url https://snapshots.lisk.io/mainnet/blockchain.db.tar.gz --output ./downloads',
 	];
 
 	static flags = {

--- a/src/commands/blockchain/download.ts
+++ b/src/commands/blockchain/download.ts
@@ -25,7 +25,7 @@ export default class DownloadCommand extends Command {
 	static examples = [
 		'download',
 		'download --network betanet',
-		'download --url https://downloads.lisk.io/lisk/mainnet/blockchain.db.tar.gz --output ./downloads',
+		'download --url https://snapshots.lisk.io/lisk/mainnet/blockchain.db.tar.gz --output ./downloads',
 	];
 
 	static flags = {

--- a/src/commands/blockchain/download.ts
+++ b/src/commands/blockchain/download.ts
@@ -13,7 +13,7 @@
  *
  */
 import { Command, flags as flagParser } from '@oclif/command';
-import { NETWORK, RELEASE_URL, DEFAULT_NETWORK } from '../../constants';
+import { NETWORK, SNAPSHOT_URL, DEFAULT_NETWORK } from '../../constants';
 import { liskSnapshotUrl } from '../../utils/commons';
 import { getFullPath } from '../../utils/path';
 import { downloadAndValidate, getChecksum } from '../../utils/download';
@@ -48,7 +48,7 @@ export default class DownloadCommand extends Command {
 	async run(): Promise<void> {
 		const { flags } = this.parse(DownloadCommand);
 		const network = flags.network ? (flags.network as NETWORK) : DEFAULT_NETWORK;
-		const url = flags.url ? flags.url : liskSnapshotUrl(RELEASE_URL, network);
+		const url = flags.url ? flags.url : liskSnapshotUrl(SNAPSHOT_URL, network);
 		const dataPath = flags.output ? flags.output : process.cwd();
 		this.log(`Downloading snapshot from ${url} to ${getFullPath(dataPath)}`);
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -22,4 +22,4 @@ export enum NETWORK {
 	DEVNET = 'devnet',
 }
 export const DEFAULT_NETWORK = NETWORK.MAINNET;
-export const RELEASE_URL = 'https://downloads.lisk.io/lisk';
+export const SNAPSHOT_URL = 'https://snapshots.lisk.io';

--- a/src/utils/commons.ts
+++ b/src/utils/commons.ts
@@ -14,14 +14,14 @@
  *
  */
 import { cryptography } from 'lisk-sdk';
-import { NETWORK, RELEASE_URL } from '../constants';
+import { NETWORK, SNAPSHOT_URL } from '../constants';
 
 export const liskSnapshotUrl = (url: string, network: NETWORK): string => {
 	if (!['testnet', 'mainnet', 'betanet'].includes(network.toLowerCase())) {
 		return '';
 	}
-	if (url && url.search(RELEASE_URL) >= 0) {
-		return `${RELEASE_URL}/${network}/blockchain.db.tar.gz`;
+	if (url && url.search(SNAPSHOT_URL) >= 0) {
+		return `${SNAPSHOT_URL}/${network}/blockchain.db.tar.gz`;
 	}
 	return url;
 };

--- a/test/commands/blockchain/download.spec.ts
+++ b/test/commands/blockchain/download.spec.ts
@@ -20,7 +20,7 @@ import DownloadCommand from '../../../src/commands/blockchain/download';
 import { getConfig } from '../../utils/config';
 
 describe('blockchain:download', () => {
-	const SNAPSHOT_URL = 'https://downloads.lisk.io/lisk/mainnet/blockchain.db.tar.gz';
+	const SNAPSHOT_URL = 'https://snapshots.lisk.io/mainnet/blockchain.db.tar.gz';
 	const dataPath = process.cwd();
 
 	let stdout: string[];

--- a/test/utils/download.spec.ts
+++ b/test/utils/download.spec.ts
@@ -18,7 +18,7 @@ import { EventEmitter } from 'events';
 import * as downloadUtil from '../../src/utils/download';
 
 describe('download utils', () => {
-	const url = 'https://downloads.lisk.io/lisk/betanet/blockchain.db.tar.gz';
+	const url = 'https://snapshots.lisk.io/betanet/blockchain.db.tar.gz';
 	const outDir = './tmp/cache/lisk-core';
 
 	describe('#download', () => {


### PR DESCRIPTION
### What was the problem?

This PR resolves #481 

### How was it solved?

- Update download command to use snapshots.lisk.io

### How was it tested?

- `./bin/run blockchain:download --help` should show snapshots.lisk.io
- `./bin/run blockchain:download -n betanet` should download the betanet blockchain snapshot