### PR TITLE
Fix lisk core start command error - Closes #503

### DIFF
--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -244,12 +244,13 @@ export default class StartCommand extends Command {
 			configFilePath: defaultConfigFilepath,
 		} = getDefaultNetworkConfigFilesPath(flags.network);
 
-		const genesisBlockExists = fs.existsSync(genesisBlockFilePath);
+		let genesisBlockExists = fs.existsSync(genesisBlockFilePath);
 		const configFileExists = fs.existsSync(configFilePath);
 
 		if (!genesisBlockExists && ['mainnet', 'testnet'].includes(flags.network)) {
 			this.log(`Genesis block from "${flags.network}" does not exists.`);
-			await DownloadCommand.run(['--network', flags.network]);
+			await DownloadCommand.run(['--network', flags.network, '--data-path', dataPath]);
+			genesisBlockExists = true;
 		}
 
 		if (

--- a/test/commands/start.spec.ts
+++ b/test/commands/start.spec.ts
@@ -123,7 +123,34 @@ describe('start', () => {
 			await StartCommand.run(['-n', 'mainnet'], config);
 
 			expect(DownloadCommand.run).toHaveBeenCalledTimes(1);
-			expect(DownloadCommand.run).toHaveBeenCalledWith(['--network', 'mainnet']);
+			expect(DownloadCommand.run).toHaveBeenCalledWith([
+				'--network',
+				'mainnet',
+				'--data-path',
+				'~/.lisk/lisk-core',
+			]);
+		});
+	});
+
+	describe('when genesis block does not exists and testnet is started with download path', () => {
+		it('should download the genesis block', async () => {
+			when(fs.existsSync as jest.Mock)
+				.calledWith('~/.lisk/lisk-core/config/testnet/genesis_block.json')
+				.mockReturnValue(false);
+			jest.spyOn(DownloadCommand, 'run').mockResolvedValue(undefined);
+
+			await StartCommand.run(
+				['-n', 'testnet', '-d', '~/.lisk/lisk-core', '--overwrite-config'],
+				config,
+			);
+
+			expect(DownloadCommand.run).toHaveBeenCalledTimes(1);
+			expect(DownloadCommand.run).toHaveBeenCalledWith([
+				'--network',
+				'testnet',
+				'--data-path',
+				'~/.lisk/lisk-core',
+			]);
 		});
 	});
 
@@ -137,7 +164,12 @@ describe('start', () => {
 			await StartCommand.run(['-n', 'testnet', '--overwrite-config'], config);
 
 			expect(DownloadCommand.run).toHaveBeenCalledTimes(1);
-			expect(DownloadCommand.run).toHaveBeenCalledWith(['--network', 'testnet']);
+			expect(DownloadCommand.run).toHaveBeenCalledWith([
+				'--network',
+				'testnet',
+				'--data-path',
+				'~/.lisk/lisk-core',
+			]);
 		});
 	});
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #503 

### How was it solved?

- Pass data path to download command in start command

### How was it tested?

- `./bin/run start -n testnet -d /tmp/testdownload`
