### PR TITLE
Offline transaction creation with --no-signature shouldn't require network ID - Closes #528

### DIFF
--- a/src/commands/transaction/create.ts
+++ b/src/commands/transaction/create.ts
@@ -134,9 +134,9 @@ export default class CreateCommand extends BaseIPCCommand {
 			throw new Error('Sender public key must be specified when no-signature flags is used.');
 		}
 
-		if (offline && !networkIdentifierSource) {
+		if (offline && !noSignature && !networkIdentifierSource) {
 			throw new Error(
-				'Flag: --network-identifier must be specified while creating transaction offline.',
+				'Flag: --network-identifier must be specified while creating transaction offline with signature.',
 			);
 		}
 

--- a/test/commands/transaction/create.spec.ts
+++ b/test/commands/transaction/create.spec.ts
@@ -191,7 +191,7 @@ describe('transaction:create command', () => {
 							config,
 						),
 					).rejects.toThrow(
-						'Flag: --network-identifier must be specified while creating transaction offline',
+						'Flag: --network-identifier must be specified while creating transaction offline with signature.',
 					);
 				});
 			});

--- a/test/commands/transaction/create.spec.ts
+++ b/test/commands/transaction/create.spec.ts
@@ -194,6 +194,24 @@ describe('transaction:create command', () => {
 						'Flag: --network-identifier must be specified while creating transaction offline with signature.',
 					);
 				});
+
+				it('should not throw error for missing network identifier flag with --no-signature', async () => {
+					await expect(
+						CreateCommand.run(
+							[
+								'2',
+								'0',
+								'100000000',
+								'--asset={"amount": "abc"}',
+								`--passphrase=${passphrase}`,
+								'--offline',
+								'--no-signature',
+								'--network=devnet',
+							],
+							config,
+						),
+					).rejects.toThrow('Sender public key must be specified when no-signature flags is used.');
+				});
 			});
 
 			describe(`transaction:create 2 0 100000000 --asset='{"amount": "abc"}' --passphrase=${passphrase} --offline`, () => {


### PR DESCRIPTION
### What was the problem?

This PR resolves #528

### How was it solved?

- Fixed the logic and enforced not to throw error with --no-signatures 

### How was it tested?

- Run unit tests 
