### PR TITLE
Update snapcraft.yaml

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -20,13 +20,18 @@ parts:
     source: .
     override-build: |
       snapcraftctl set-version "$(jq -r .version < package.json)"
-      export PATH=$PWD/../npm/bin:$PATH
+      export PATH=/root/parts/lisk-core/npm/bin:$PATH
+      cd ..
+      git clone https://github.com/LiskHQ/dev-cli || true
+      cd dev-cli
       npm install --global yarn
       npm install --global typescript
-      npm install --global @oclif/dev-cli --registry https://npm.lisk.io
+      yarn
+      npm run build
+      cd ../build
       npm ci
       npm run build
-      oclif-dev pack --targets=linux-x64
+      ../dev-cli/bin/run pack --targets=linux-x64
       cd dist
       find . -name \*linux\*.tar.gz -exec cp {} /root/parts/lisk-core/install \;
       cd ../../install

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -21,20 +21,15 @@ parts:
     override-build: |
       snapcraftctl set-version "$(jq -r .version < package.json)"
       export PATH=$PWD/../npm/bin:$PATH
-      cd ..
-      git clone https://github.com/LiskHQ/dev-cli || true
-      cd dev-cli
       npm install --global yarn
       npm install --global typescript
-      yarn
-      npm run build
-      yarn global add link:$PWD
-      cd ../build
+      npm install --global @oclif/dev-cli --registry https://npm.lisk.io
       npm ci
       npm run build
       oclif-dev pack --targets=linux-x64
-      cp dist/channels/*/*/*linux*.tar.gz ../install
-      cd ../install
+      cd dist
+      find . -name \*linux\*.tar.gz -exec cp {} /root/parts/lisk-core/install \;
+      cd ../../install
       tar -zvxf *.tar.gz
       rm *.tar.gz
       mkdir bin


### PR DESCRIPTION
This is to reliably build snaps, whether it's a production or beta/rc/etc build.

### What was the problem?

snapcraft.yaml didn't account for the different output locations of production builds vs beta/etc builds.
It was also a little unreliable with how it was installing oclif-dev, this is changed to use our build in npm.lisk.io and now works everytime.

### How was it solved?

Updated and simplified snapcraft.yaml

### How was it tested?

Built local snaps of multiple versions and tested them
