### PR TITLE
Update default LISK_PORT value - Closes #611

### DIFF
--- a/config/betanet/config.json
+++ b/config/betanet/config.json
@@ -32,26 +32,26 @@
 		"seedPeers": [
 			{
 				"ip": "betanet5-seed-01.lisk.com",
-				"port": 7668
+				"port": 7667
 			},
 			{
 				"ip": "betanet5-seed-02.lisk-nodes.net",
-				"port": 7668
+				"port": 7667
 			},
 			{
 				"ip": "betanet5-seed-03.lisk.com",
-				"port": 7668
+				"port": 7667
 			},
 			{
 				"ip": "betanet5-seed-04.lisk-nodes.net",
-				"port": 7668
+				"port": 7667
 			},
 			{
 				"ip": "betanet5-seed-05.lisk.com",
-				"port": 7668
+				"port": 7667
 			}
 		],
-		"port": 7668
+		"port": 7667
 	},
 	"forging": {
 		"waitThreshold": 2,


### PR DESCRIPTION
### What was the problem?

This PR resolves #611 

### How was it solved?

- [x] Update port value to `7667` for `betanet`

### How was it tested?

- Unable to run betanet. Requires genesis block update.
