### PR TITLE
Expose legacy assets schema

### DIFF
--- a/src/application/modules/legacy/module.ts
+++ b/src/application/modules/legacy/module.ts
@@ -90,7 +90,12 @@ export class LegacyModule extends BaseModule {
 				params: command.schema,
 			})),
 			events: [],
-			assets: [],
+			assets: [
+				{
+					version: 0,
+					data: genesisLegacyStoreSchema,
+				},
+			],
 		};
 	}
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #691 

### How was it solved?

- [x] Expose genesis asset schema in metadata for `legacy` module

### How was it tested?

- `nvm use`
- `npm install --registry https://npm.lisk.com`
- `npm run build`
- `./bin/run endpoint invoke system_getMetadata`
