### PR TITLE
Fix event names for legacy module

### DIFF
--- a/config/devnet/config.json
+++ b/config/devnet/config.json
@@ -2,7 +2,7 @@
 	"system": {
 		"dataPath": "~/.lisk",
 		"logLevel": "info",
-		"keepEventsForHeights": 300
+		"keepEventsForHeights": -1
 	},
 	"rpc": {
 		"modes": ["ipc", "ws"],

--- a/src/application/modules/legacy/commands/reclaim.ts
+++ b/src/application/modules/legacy/commands/reclaim.ts
@@ -29,7 +29,7 @@ import { reclaimLSKParamsSchema } from '../schemas';
 import { ReclaimLSKParamsData, TokenIDReclaim, ModuleName } from '../types';
 import { getLegacyAddress } from '../utils';
 import { LegacyAccountStore } from '../stores/legacyAccountStore';
-import { ReclaimLSKEvent } from '../events/reclaim';
+import { AccountReclaimedEvent } from '../events/accountReclaimed';
 
 // eslint-disable-next-line prefer-destructuring
 const validator: liskValidator.LiskValidator = liskValidator.validator;
@@ -113,8 +113,8 @@ export class ReclaimLSKCommand extends BaseCommand {
 			params.amount,
 		);
 
-		const reclaimLSKEvent = this.events.get(ReclaimLSKEvent);
-		reclaimLSKEvent.log(ctx.getMethodContext(), {
+		const accountReclaimedEvent = this.events.get(AccountReclaimedEvent);
+		accountReclaimedEvent.log(ctx.getMethodContext(), {
 			legacyAddress,
 			address,
 			amount: params.amount,

--- a/src/application/modules/legacy/commands/register_keys.ts
+++ b/src/application/modules/legacy/commands/register_keys.ts
@@ -25,7 +25,7 @@ import {
 import { INVALID_BLS_KEY } from '../constants';
 import { registerKeysParamsSchema } from '../schemas';
 import { registerKeysData } from '../types';
-import { RegisterKeysEvent } from '../events/registerKeys';
+import { KeysRegisteredEvent } from '../events/keysRegistered';
 
 const {
 	address: { getAddressFromPublicKey },
@@ -79,8 +79,8 @@ export class RegisterKeysCommand extends BaseCommand {
 			params.proofOfPossession,
 		);
 
-		const registerKeysEvent = this.events.get(RegisterKeysEvent);
-		registerKeysEvent.log(ctx.getMethodContext(), {
+		const keysRegisteredEvent = this.events.get(KeysRegisteredEvent);
+		keysRegisteredEvent.log(ctx.getMethodContext(), {
 			address: validatorAddress,
 			generatorKey: params.generatorKey,
 			blsKey: params.blsKey,

--- a/src/application/modules/legacy/events/accountReclaimed.ts
+++ b/src/application/modules/legacy/events/accountReclaimed.ts
@@ -15,7 +15,7 @@ import { BaseEvent, EventQueuer } from 'lisk-sdk';
 
 import { LENGTH_LEGACY_ADDRESS, LENGTH_ADDRESS } from '../constants';
 
-export interface reclaimLSKEventData {
+export interface accountReclaimedEventData {
 	legacyAddress: Buffer;
 	address: Buffer;
 	amount: bigint;
@@ -43,10 +43,10 @@ export const accountReclaimedEventDataSchema = {
 	},
 };
 
-export class ReclaimLSKEvent extends BaseEvent<reclaimLSKEventData> {
+export class AccountReclaimedEvent extends BaseEvent<accountReclaimedEventData> {
 	public schema = accountReclaimedEventDataSchema;
 
-	public log(ctx: EventQueuer, data: reclaimLSKEventData): void {
+	public log(ctx: EventQueuer, data: accountReclaimedEventData): void {
 		this.add(ctx, data, [data.legacyAddress, data.address]);
 	}
 }

--- a/src/application/modules/legacy/events/keysRegistered.ts
+++ b/src/application/modules/legacy/events/keysRegistered.ts
@@ -15,7 +15,7 @@ import { BaseEvent, EventQueuer } from 'lisk-sdk';
 
 import { LENGTH_ADDRESS, LENGTH_GENERATOR_KEY, LENGTH_BLS_KEY } from '../constants';
 
-export interface registerKeysEventData {
+export interface keysRegisteredEventData {
 	address: Buffer;
 	generatorKey: Buffer;
 	blsKey: Buffer;
@@ -44,10 +44,10 @@ export const keysRegisteredEventDataSchema = {
 	},
 };
 
-export class RegisterKeysEvent extends BaseEvent<registerKeysEventData> {
+export class KeysRegisteredEvent extends BaseEvent<keysRegisteredEventData> {
 	public schema = keysRegisteredEventDataSchema;
 
-	public log(ctx: EventQueuer, data: registerKeysEventData): void {
+	public log(ctx: EventQueuer, data: keysRegisteredEventData): void {
 		this.add(ctx, data, [data.address, data.generatorKey, data.blsKey]);
 	}
 }

--- a/src/application/modules/legacy/module.ts
+++ b/src/application/modules/legacy/module.ts
@@ -41,8 +41,8 @@ import { getModuleConfig } from './utils';
 import { LegacyAccountStore } from './stores/legacyAccountStore';
 import { ReclaimLSKCommand } from './commands/reclaim';
 import { RegisterKeysCommand } from './commands/register_keys';
-import { ReclaimLSKEvent } from './events/reclaim';
-import { RegisterKeysEvent } from './events/registerKeys';
+import { AccountReclaimedEvent } from './events/accountReclaimed';
+import { KeysRegisteredEvent } from './events/keysRegistered';
 
 // eslint-disable-next-line prefer-destructuring
 const validator: liskValidator.LiskValidator = liskValidator.validator;
@@ -65,8 +65,8 @@ export class LegacyModule extends BaseModule {
 		this.stores.register(LegacyAccountStore, new LegacyAccountStore(this.name, 0));
 
 		// Register events
-		this.events.register(ReclaimLSKEvent, new ReclaimLSKEvent(this.name));
-		this.events.register(RegisterKeysEvent, new RegisterKeysEvent(this.name));
+		this.events.register(AccountReclaimedEvent, new AccountReclaimedEvent(this.name));
+		this.events.register(KeysRegisteredEvent, new KeysRegisteredEvent(this.name));
 	}
 
 	// eslint-disable-next-line @typescript-eslint/member-ordering

--- a/test/scripts/stress_test.ts
+++ b/test/scripts/stress_test.ts
@@ -150,10 +150,6 @@ const start = async (count, roundNumber) => {
 	for (let i = 0; i < accountsLen; i++) {
 		const stakes: Stake[] = [
 			{ validatorAddress: accounts[accountsLen - i - 1].address, amount: getBeddows('20') },
-			{
-				validatorAddress: 'lskzort5bybu4rchqk6aj7sx2bbsu4azwf3wbutu4',
-				amount: BigInt('1000000000'),
-			},
 		];
 		await sendStakeTransaction(accounts[i], stakes, client);
 	}
@@ -245,7 +241,8 @@ const start = async (count, roundNumber) => {
 		const account = await genesisAccount(keyPath);
 		await sendTokenTransferTransaction(fundInitialAccount[0], account, client);
 
-		if (roundNumber === 0) {
+		// TODO: Dirty hack. Handle this separately
+		if (roundNumber === 0 && network !== 'devnet') {
 			const params = {
 				blsKey: validatorKeys[i].plain.blsKey,
 				proofOfPossession: validatorKeys[i].plain.blsProofOfPossession,


### PR DESCRIPTION
### What was the problem?

This PR resolves #739 

### How was it solved?

- [x] Update legacy module event names as below:
  - reclaimLSK --> accountReclaimed
  - registerKeys --> keysRegistered
- [x] Update the stress test script
- [x] Update devnet config to persist all the events

### How was it tested?

Locally
