### PR TITLE
Test docker set up page 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ build-local:
 clean: clean-image clean-local
 
 clean-image:
-	docker rmi lisk/core
+	docker rmi lisk/core; :
 
 clean-local:
 	rm -rf dist/ node_modules/
@@ -66,7 +66,7 @@ start: check-args
 	docker run -d -p 7887:7887 -p 7667:7667 --name lisk-core --rm lisk/core start $(ARGS)
 
 stop:
-	docker stop lisk-core
+	docker stop lisk-core; :
 
 logs:
 	docker logs lisk-core
@@ -74,7 +74,7 @@ logs:
 logs-live:
 	docker logs lisk-core --follow
 
-# Usage: make run ARGS="start help"
+# Usage: make run ARGS="start --help"
 run: check-args
 	docker run --name lisk-core-temp --rm lisk/core $(ARGS)
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -2,7 +2,7 @@
 
 lisk/core version 4 does not have any external dependencies and thus does not require using `docker-compose`.
 
-Note: [podman](https://github.com/containers/podman/) can be used. Simply replace occurrences of `docker` with `podman` or `alias docker=podman`.
+Note: It is also possible to use [podman](https://github.com/containers/podman/) instead of docker by simply replacing the occurrences of docker with podman, in the following examples or alternatively by creating an alias with `alias docker=podman`.
 
 ## Run
 
@@ -13,7 +13,7 @@ docker run --volume lisk-data:/home/lisk/.lisk \
            --publish 7667:7667 \
            --name lisk-core \
            lisk/core:4.0.0 \
-             start --network=betanet
+           start --network=betanet
 ```
 
 ### Configuration
@@ -26,7 +26,7 @@ docker run --volume lisk-data:/home/lisk/.lisk \
            --publish 127.0.0.1:7887:7887 \
            --name lisk-core \
            lisk/core:4.0.0 \
-             start --network=betanet --api-ws --api-http --log=debug
+           start --network=betanet --api-ws --api-http --log=debug
 ```
 
 Environment variables can be set with `--env`:
@@ -37,7 +37,7 @@ docker run --volume lisk-data:/home/lisk/.lisk \
            --env LISK_LOG_LEVEL=debug \
            --name lisk-core \
            lisk/core:4.0.0 \
-             start --network=betanet
+           start --network=betanet
 ```
 
 See https://lisk.com/documentation/lisk-core/management/configuration.html for a reference of configuration options.

--- a/docs/antora/modules/ROOT/pages/setup/docker.adoc
+++ b/docs/antora/modules/ROOT/pages/setup/docker.adoc
@@ -118,7 +118,7 @@ docker run --volume lisk-data:/home/lisk/.lisk \
            --publish 7887:7887 \
            --name lisk-core \
            lisk/core:4.0.0 \
-             start --network=mainnet
+           start --network=mainnet
 ----
 
 [NOTE]
@@ -158,7 +158,7 @@ docker run --volume lisk-data:/home/lisk/.lisk \
            --publish 7887:7887 \
            --name lisk-core \
            lisk/core:4.0.0 \
-             start --network=testnet
+           start --network=testnet
 ----
 --
 ====
@@ -174,7 +174,7 @@ docker run --volume lisk-data:/home/lisk/.lisk \
            --publish 127.0.0.1:7887:7887 \
            --name lisk-core \
            lisk/core:4.0.0 \
-             start --network=testnet --api-ws --api-http --log=debug
+           start --network=testnet --api-ws --api-http --log=debug
 ----
 
 Environment variables can be set with `--env`:
@@ -186,7 +186,7 @@ docker run --volume lisk-data:/home/lisk/.lisk \
            --env LISK_CONSOLE_LOG_LEVEL=debug \
            --name lisk-core \
            lisk/core:4.0.0 \
-             start --network=mainnet
+           start --network=mainnet
 ----
 
 //TODO: Add link back, once docs are updated

--- a/docs/antora/modules/ROOT/pages/setup/docker.adoc
+++ b/docs/antora/modules/ROOT/pages/setup/docker.adoc
@@ -113,7 +113,7 @@ Mainnet::
 [source,bash]
 ----
 docker run --volume lisk-data:/home/lisk/.lisk \
-           --publish 5001:5001 \
+           --publish 7887:7887 \
            --name lisk-core \
            lisk/core:4.0.0 \
              start --network=mainnet
@@ -153,7 +153,7 @@ Testnet::
 [source,bash]
 ----
 docker run --volume lisk-data:/home/lisk/.lisk \
-           --publish 5001:5001 \
+           --publish 7887:7887 \
            --name lisk-core \
            lisk/core:4.0.0 \
              start --network=testnet
@@ -168,8 +168,8 @@ Further parameters can be passed after `--network`, for example, as shown below:
 [source,bash]
 ----
 docker run --volume lisk-data:/home/lisk/.lisk \
-           --publish 5001:5001 \
-           --publish 127.0.0.1:5000:5000 \
+           --publish 7887:7887 \
+           --publish 127.0.0.1:7667:7667 \
            --name lisk-core \
            lisk/core:4.0.0 \
              start --network=testnet --enable-http-api-plugin
@@ -180,7 +180,7 @@ Environment variables can be set with `--env`:
 [source,bash]
 ----
 docker run --volume lisk-data:/home/lisk/.lisk \
-           --publish 5001:5001 \
+           --publish 7887:7887 \
            --env LISK_CONSOLE_LOG_LEVEL=debug \
            --name lisk-core \
            lisk/core:4.0.0 \

--- a/docs/antora/modules/ROOT/pages/setup/docker.adoc
+++ b/docs/antora/modules/ROOT/pages/setup/docker.adoc
@@ -98,8 +98,10 @@ NOTE: Please check for the latest release in the {url_core_releases}[Lisk Core r
 .Podman
 [NOTE]
 ====
-{url_podman}[podman] can be used.
-Simply replace occurrences of `docker` with `podman` or `alias docker=podman`.
+It is also possible to use {url_podman}[podman] instead of docker by simply replacing the occurrences of docker with `podman`, in the following examples or alternatively by creating an alias with the alias `docker=podman`.
+// Simply replace occurrences of `docker` with `podman` or `alias docker=podman`.
+
+
 ====
 
 Create a "lisk-core" container:

--- a/docs/antora/modules/ROOT/pages/setup/docker.adoc
+++ b/docs/antora/modules/ROOT/pages/setup/docker.adoc
@@ -98,7 +98,7 @@ NOTE: Please check for the latest release in the {url_core_releases}[Lisk Core r
 .Podman
 [NOTE]
 ====
-It is also possible to use {url_podman}[podman] instead of docker by simply replacing the occurrences of docker with `podman`, in the following examples or alternatively by creating an alias with the alias `docker=podman`.
+It is also possible to use {url_podman}[podman] instead of docker by simply replacing the occurrences of docker with `podman`, in the following examples or alternatively by creating an alias with `alias docker=podman`.
 // Simply replace occurrences of `docker` with `podman` or `alias docker=podman`.
 
 

--- a/docs/antora/modules/ROOT/pages/setup/docker.adoc
+++ b/docs/antora/modules/ROOT/pages/setup/docker.adoc
@@ -170,11 +170,11 @@ Further parameters can be passed after `--network`, for example, as shown below:
 [source,bash]
 ----
 docker run --volume lisk-data:/home/lisk/.lisk \
-           --publish 7887:7887 \
-           --publish 127.0.0.1:7667:7667 \
+           --publish 7667:7667 \
+           --publish 127.0.0.1:7887:7887 \
            --name lisk-core \
            lisk/core:4.0.0 \
-             start --network=testnet --enable-http-api-plugin
+             start --network=testnet --api-ws --api-http --log=debug
 ----
 
 Environment variables can be set with `--env`:
@@ -182,27 +182,17 @@ Environment variables can be set with `--env`:
 [source,bash]
 ----
 docker run --volume lisk-data:/home/lisk/.lisk \
-           --publish 7887:7887 \
+           --publish 7667:7667 \
            --env LISK_CONSOLE_LOG_LEVEL=debug \
            --name lisk-core \
            lisk/core:4.0.0 \
-             start --network=testnet
+             start --network=mainnet
 ----
 
 //TODO: Add link back, once docs are updated
 //See the xref:{url_config}[] guide for a reference of more configuration options.
 
-An example with all possible flags set is shown below:
 
-[source,bash]
-----
-docker run -d --volume /data:/home/lisk/.lisk \
-    --publish 7000:7000 --publish 8080:8080 --publish 7008:7008\
-    --name lisk-core lisk/core:4.0.0 start --network=testnet --port 7000\
-    --api-ws --enable-http-api-plugin --http-api-plugin-port 7008\
-    --http-api-plugin-host host.docker.internal --http-api-plugin-whitelist 0.0.0.0/0 \
-    --api-ws --api-ws-port 8080 --api-ws-host 0.0.0.0
-----
 
 == Import blockchain snapshot
 


### PR DESCRIPTION
When Lisk core v4 image is ready and the beta version is available, then test the Docker set up with lisk-core v4.

lisk-docs/lisk-core/v4/setup/docker.html

(This issue pertains to the already merged PR Update Docker setup page: https://github.com/LiskHQ/lisk-docs/pull/1642)







Closes #1605 in docs-core 