### PR TITLE
Update Lisk SDK to v6.0.1

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -12,8 +12,8 @@ Create a "lisk-core" container for betanet:
 docker run --volume lisk-data:/home/lisk/.lisk \
            --publish 7667:7667 \
            --name lisk-core \
-           lisk/core:4.0.0 \
-           start --network=betanet
+           lisk/core:4.0.1 \
+           start --network=mainnet
 ```
 
 ### Configuration
@@ -25,8 +25,8 @@ docker run --volume lisk-data:/home/lisk/.lisk \
            --publish 7667:7667 \
            --publish 127.0.0.1:7887:7887 \
            --name lisk-core \
-           lisk/core:4.0.0 \
-           start --network=betanet --api-ws --api-http --log=debug
+           lisk/core:4.0.1 \
+           start --network=mainnet --api-ws --api-http --log=debug
 ```
 
 Environment variables can be set with `--env`:
@@ -36,8 +36,8 @@ docker run --volume lisk-data:/home/lisk/.lisk \
            --publish 7667:7667 \
            --env LISK_LOG_LEVEL=debug \
            --name lisk-core \
-           lisk/core:4.0.0 \
-           start --network=betanet
+           lisk/core:4.0.1 \
+           start --network=mainnet
 ```
 
 See https://lisk.com/documentation/lisk-core/management/configuration.html for a reference of configuration options.
@@ -45,11 +45,11 @@ See https://lisk.com/documentation/lisk-core/management/configuration.html for a
 ## Import blockchain snapshot
 
 ```
-docker run --volume lisk-data:/home/lisk/.lisk -it --rm lisk/core:4.0.0 blockchain:download --network=betanet --output=/home/lisk/.lisk/tmp/
+docker run --volume lisk-data:/home/lisk/.lisk -it --rm lisk/core:4.0.1 blockchain:download --network=mainnet --output=/home/lisk/.lisk/tmp/
 
-docker run --volume lisk-data:/home/lisk/.lisk -it --rm lisk/core:4.0.0 blockchain:import /home/lisk/.lisk/tmp/blockchain.db.tar.gz
+docker run --volume lisk-data:/home/lisk/.lisk -it --rm lisk/core:4.0.1 blockchain:import /home/lisk/.lisk/tmp/blockchain.db.tar.gz
 
-docker run --volume lisk-data:/home/lisk/.lisk -it --rm --entrypoint rm lisk/core:4.0.0 -f /home/lisk/.lisk/tmp/blockchain.db.tar.gz
+docker run --volume lisk-data:/home/lisk/.lisk -it --rm --entrypoint rm lisk/core:4.0.1 -f /home/lisk/.lisk/tmp/blockchain.db.tar.gz
 
 docker start lisk-core
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -6,7 +6,7 @@ Note: It is also possible to use [podman](https://github.com/containers/podman/)
 
 ## Run
 
-Create a "lisk-core" container for betanet:
+Run a "lisk-core" container against the mainnet:
 
 ```
 docker run --volume lisk-data:/home/lisk/.lisk \

--- a/package.json
+++ b/package.json
@@ -107,11 +107,11 @@
 		}
 	},
 	"dependencies": {
-		"@liskhq/lisk-framework-faucet-plugin": "0.3.0",
-		"@liskhq/lisk-framework-forger-plugin": "0.4.0",
-		"@liskhq/lisk-framework-monitor-plugin": "0.4.0",
-		"@liskhq/lisk-framework-report-misbehavior-plugin": "0.4.0",
-		"@liskhq/lisk-framework-chain-connector-plugin": "0.1.0",
+		"@liskhq/lisk-framework-faucet-plugin": "0.3.1",
+		"@liskhq/lisk-framework-forger-plugin": "0.4.1",
+		"@liskhq/lisk-framework-monitor-plugin": "0.4.1",
+		"@liskhq/lisk-framework-report-misbehavior-plugin": "0.4.1",
+		"@liskhq/lisk-framework-chain-connector-plugin": "0.1.1",
 		"@oclif/core": "1.20.4",
 		"@oclif/plugin-autocomplete": "1.3.6",
 		"@oclif/plugin-help": "5.1.19",
@@ -119,8 +119,8 @@
 		"axios": "1.6.0",
 		"fs-extra": "11.1.0",
 		"inquirer": "8.2.5",
-		"lisk-commander": "6.0.0",
-		"lisk-sdk": "6.0.0",
+		"lisk-commander": "6.0.1",
+		"lisk-sdk": "6.0.1",
 		"tar": "6.1.11",
 		"tslib": "2.4.1"
 	},

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,12 +22,12 @@
   dependencies:
     "@babel/highlight" "^7.10.4"
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.22.13":
-  version "7.22.13"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.22.13.tgz#e3c1c099402598483b7a8c46a721d1038803755e"
-  integrity sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.22.13", "@babel/code-frame@^7.23.4":
+  version "7.23.4"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.23.4.tgz#03ae5af150be94392cb5c7ccd97db5a19a5da6aa"
+  integrity sha512-r1IONyb6Ia+jYR2vvIDhdWdlTGhqbBoFqLTQidzZ4kepUFH15ejXvFHxCVbtl7BOXIudsIubf4E81xeA3h3IXA==
   dependencies:
-    "@babel/highlight" "^7.22.13"
+    "@babel/highlight" "^7.23.4"
     chalk "^2.4.2"
 
 "@babel/compat-data@^7.22.9":
@@ -56,12 +56,12 @@
     json5 "^2.2.3"
     semver "^6.3.1"
 
-"@babel/generator@^7.23.3", "@babel/generator@^7.7.2":
-  version "7.23.3"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.23.3.tgz#86e6e83d95903fbe7613f448613b8b319f330a8e"
-  integrity sha512-keeZWAV4LU3tW0qRi19HRpabC/ilM0HRBBzf9/k8FFiG4KVpiv0FIy4hHfLfFQZNhziCTPTmd59zoyv6DNISzg==
+"@babel/generator@^7.23.3", "@babel/generator@^7.23.4", "@babel/generator@^7.7.2":
+  version "7.23.4"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.23.4.tgz#4a41377d8566ec18f807f42962a7f3551de83d1c"
+  integrity sha512-esuS49Cga3HcThFNebGhlgsrVLkvhqvYDTzgjfFFlHJcIfLe5jFmRRfCQ1KuBfc4Jrtn3ndLgKWAKjBE+IraYQ==
   dependencies:
-    "@babel/types" "^7.23.3"
+    "@babel/types" "^7.23.4"
     "@jridgewell/gen-mapping" "^0.3.2"
     "@jridgewell/trace-mapping" "^0.3.17"
     jsesc "^2.5.1"
@@ -134,10 +134,10 @@
   dependencies:
     "@babel/types" "^7.22.5"
 
-"@babel/helper-string-parser@^7.22.5":
-  version "7.22.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz#533f36457a25814cf1df6488523ad547d784a99f"
-  integrity sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==
+"@babel/helper-string-parser@^7.23.4":
+  version "7.23.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz#9478c707febcbbe1ddb38a3d91a2e054ae622d83"
+  integrity sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==
 
 "@babel/helper-validator-identifier@^7.22.20":
   version "7.22.20"
@@ -150,27 +150,27 @@
   integrity sha512-bMn7RmyFjY/mdECUbgn9eoSY4vqvacUnS9i9vGAGttgFWesO6B4CYWA7XlpbWgBt71iv/hfbPlynohStqnu5hA==
 
 "@babel/helpers@^7.23.2":
-  version "7.23.2"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.23.2.tgz#2832549a6e37d484286e15ba36a5330483cac767"
-  integrity sha512-lzchcp8SjTSVe/fPmLwtWVBFC7+Tbn8LGHDVfDp9JGxpAY5opSaEFgt8UQvrnECWOTdji2mOWMz1rOhkHscmGQ==
+  version "7.23.4"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.23.4.tgz#7d2cfb969aa43222032193accd7329851facf3c1"
+  integrity sha512-HfcMizYz10cr3h29VqyfGL6ZWIjTwWfvYBMsBVGwpcbhNGe3wQ1ZXZRPzZoAHhd9OqHadHqjQ89iVKINXnbzuw==
   dependencies:
     "@babel/template" "^7.22.15"
-    "@babel/traverse" "^7.23.2"
-    "@babel/types" "^7.23.0"
+    "@babel/traverse" "^7.23.4"
+    "@babel/types" "^7.23.4"
 
-"@babel/highlight@^7.10.4", "@babel/highlight@^7.22.13":
-  version "7.22.20"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.22.20.tgz#4ca92b71d80554b01427815e06f2df965b9c1f54"
-  integrity sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==
+"@babel/highlight@^7.10.4", "@babel/highlight@^7.23.4":
+  version "7.23.4"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.23.4.tgz#edaadf4d8232e1a961432db785091207ead0621b"
+  integrity sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==
   dependencies:
     "@babel/helper-validator-identifier" "^7.22.20"
     chalk "^2.4.2"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.14.7", "@babel/parser@^7.20.7", "@babel/parser@^7.22.15", "@babel/parser@^7.23.3":
-  version "7.23.3"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.23.3.tgz#0ce0be31a4ca4f1884b5786057cadcb6c3be58f9"
-  integrity sha512-uVsWNvlVsIninV2prNz/3lHCb+5CJ+e+IUBfbjToAHODtfGYLfCFuY4AU7TskI+dAKk+njsPiBjq1gKTvZOBaw==
+"@babel/parser@^7.1.0", "@babel/parser@^7.14.7", "@babel/parser@^7.20.7", "@babel/parser@^7.22.15", "@babel/parser@^7.23.3", "@babel/parser@^7.23.4":
+  version "7.23.4"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.23.4.tgz#409fbe690c333bb70187e2de4021e1e47a026661"
+  integrity sha512-vf3Xna6UEprW+7t6EtOmFpHNAuxw3xqPZghy+brsnusscJRW5BMUzzHZc5ICjULee81WeUV2jjakG09MDglJXQ==
 
 "@babel/plugin-syntax-async-generators@^7.8.4":
   version "7.8.4"
@@ -271,9 +271,9 @@
     "@babel/helper-plugin-utils" "^7.22.5"
 
 "@babel/runtime@^7.1.2", "@babel/runtime@^7.12.13":
-  version "7.23.2"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.2.tgz#062b0ac103261d68a966c4c7baf2ae3e62ec3885"
-  integrity sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==
+  version "7.23.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.4.tgz#36fa1d2b36db873d25ec631dcc4923fdc1cf2e2e"
+  integrity sha512-2Yv65nlWnWlSpe3fXEyX5i7fx5kIKo4Qbcj+hMO0odwaneFjfXw5fdum+4yL20O0QiaHpia0cYQ9xpNMqrBwHg==
   dependencies:
     regenerator-runtime "^0.14.0"
 
@@ -286,28 +286,28 @@
     "@babel/parser" "^7.22.15"
     "@babel/types" "^7.22.15"
 
-"@babel/traverse@^7.23.2", "@babel/traverse@^7.23.3":
-  version "7.23.3"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.23.3.tgz#26ee5f252e725aa7aca3474aa5b324eaf7908b5b"
-  integrity sha512-+K0yF1/9yR0oHdE0StHuEj3uTPzwwbrLGfNOndVJVV2TqA5+j3oljJUb4nmB954FLGjNem976+B+eDuLIjesiQ==
+"@babel/traverse@^7.23.3", "@babel/traverse@^7.23.4":
+  version "7.23.4"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.23.4.tgz#c2790f7edf106d059a0098770fe70801417f3f85"
+  integrity sha512-IYM8wSUwunWTB6tFC2dkKZhxbIjHoWemdK+3f8/wq8aKhbUscxD5MX72ubd90fxvFknaLPeGw5ycU84V1obHJg==
   dependencies:
-    "@babel/code-frame" "^7.22.13"
-    "@babel/generator" "^7.23.3"
+    "@babel/code-frame" "^7.23.4"
+    "@babel/generator" "^7.23.4"
     "@babel/helper-environment-visitor" "^7.22.20"
     "@babel/helper-function-name" "^7.23.0"
     "@babel/helper-hoist-variables" "^7.22.5"
     "@babel/helper-split-export-declaration" "^7.22.6"
-    "@babel/parser" "^7.23.3"
-    "@babel/types" "^7.23.3"
+    "@babel/parser" "^7.23.4"
+    "@babel/types" "^7.23.4"
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/types@^7.0.0", "@babel/types@^7.20.7", "@babel/types@^7.22.15", "@babel/types@^7.22.5", "@babel/types@^7.23.0", "@babel/types@^7.23.3", "@babel/types@^7.3.3":
-  version "7.23.3"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.23.3.tgz#d5ea892c07f2ec371ac704420f4dcdb07b5f9598"
-  integrity sha512-OZnvoH2l8PK5eUvEcUyCt/sXgr/h+UWpVuBbOljwcrAgUl6lpchoQ++PHGyQy1AtYnVA6CEq3y5xeEI10brpXw==
+"@babel/types@^7.0.0", "@babel/types@^7.20.7", "@babel/types@^7.22.15", "@babel/types@^7.22.5", "@babel/types@^7.23.0", "@babel/types@^7.23.3", "@babel/types@^7.23.4", "@babel/types@^7.3.3":
+  version "7.23.4"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.23.4.tgz#7206a1810fc512a7f7f7d4dace4cb4c1c9dbfb8e"
+  integrity sha512-7uIFwVYpoplT5jp/kVv6EF93VaJ8H+Yn5IczYiaAi98ajzjfoZfslet/e0sLh+wVBjb2qqIut1b0S26VSafsSQ==
   dependencies:
-    "@babel/helper-string-parser" "^7.22.5"
+    "@babel/helper-string-parser" "^7.23.4"
     "@babel/helper-validator-identifier" "^7.22.20"
     to-fast-properties "^2.0.0"
 
@@ -651,10 +651,10 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@liskhq/lisk-api-client@^6.0.0":
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/@liskhq/lisk-api-client/-/lisk-api-client-6.0.0.tgz#2d0fbf128f4341b394154bd1987a688008c38578"
-  integrity sha512-IdApCNokD8TBbxf3ovuQ9Htd1VkhUkifWVt3bM000VAI7Qg7JxZismLvH3P/fhEIEh4xzdyj1bMP7TdZWF0v7Q==
+"@liskhq/lisk-api-client@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@liskhq/lisk-api-client/-/lisk-api-client-6.0.1.tgz#5b78a48c3c98b047391e07114eb05887709a6f85"
+  integrity sha512-eyyZz0ZAUiGKCX9armNkEpYVmb/yz2JhKL6OygDUtbPO7X7V6Ofu7XH+mBoPdtPEyNhi59idSnJuOclpZ5kWtw==
   dependencies:
     "@liskhq/lisk-codec" "^0.4.0"
     "@liskhq/lisk-cryptography" "^4.0.0"
@@ -677,12 +677,12 @@
     "@liskhq/lisk-validator" "^0.8.0"
     debug "4.3.4"
 
-"@liskhq/lisk-client@^6.0.0":
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/@liskhq/lisk-client/-/lisk-client-6.0.0.tgz#ad107bad739a90d38b91243fc453f0050079eb75"
-  integrity sha512-+z9WozvWRj9l0rKIPYeVyBv9jvaiWhrJPLwgx+paAbypD50PUzFsEXMSOfsHR6hjwfnvfTBbhCD5eGvWRdBA9Q==
+"@liskhq/lisk-client@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@liskhq/lisk-client/-/lisk-client-6.0.1.tgz#17e1727ae829b98b1ddca4393785987c015bf7e8"
+  integrity sha512-RdaFHNuCmjVLZbzAqF/BboszZJCpgqOUpb5SKsQOyHBLZA2/x76sZURb0DA0XBRbb1vxDh3GC2F9a3OrWf7sKQ==
   dependencies:
-    "@liskhq/lisk-api-client" "^6.0.0"
+    "@liskhq/lisk-api-client" "^6.0.1"
     "@liskhq/lisk-codec" "^0.4.0"
     "@liskhq/lisk-cryptography" "^4.0.0"
     "@liskhq/lisk-passphrase" "^4.0.0"
@@ -721,62 +721,62 @@
     cargo-cp-artifact "^0.1"
     shelljs "^0.8.5"
 
-"@liskhq/lisk-framework-chain-connector-plugin@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@liskhq/lisk-framework-chain-connector-plugin/-/lisk-framework-chain-connector-plugin-0.1.0.tgz#e5826feb0060efbe23b491f777abc792d50fe84b"
-  integrity sha512-8M3v6DLEpfbeJVHG8SJS6wxicVRkNYsAASIJYnOapEaq6CRy945GFfHq8G4s+zhbGfeMVE6wq1fqdQ0a+saZBg==
+"@liskhq/lisk-framework-chain-connector-plugin@0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@liskhq/lisk-framework-chain-connector-plugin/-/lisk-framework-chain-connector-plugin-0.1.1.tgz#700d7580788c5a077a322d741b35b6122a056a06"
+  integrity sha512-aMRkBCp6I5ATpqxQvsyDMTCLlvENkJbAtRYnRiYFnHgyCBuM6OhUPX+SiAf2N8A2/ODaIhaOw57jJk1tcGJLnQ==
   dependencies:
     debug "4.3.4"
     fs-extra "11.1.0"
-    lisk-sdk "^6.0.0"
+    lisk-sdk "^6.0.1"
 
-"@liskhq/lisk-framework-faucet-plugin@0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@liskhq/lisk-framework-faucet-plugin/-/lisk-framework-faucet-plugin-0.3.0.tgz#4f32161b734cfbd6837874a7aebc1048e3635c3c"
-  integrity sha512-LqPl6x+ZFWRpbdfibjnH9QHo/W9uXNIO2CF7Zd7Haq5b9LprqdjHr18PBPRg9lct6aQVC6/ONJsssi9JFlsWrw==
+"@liskhq/lisk-framework-faucet-plugin@0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@liskhq/lisk-framework-faucet-plugin/-/lisk-framework-faucet-plugin-0.3.1.tgz#c99ad80413d813fc663918fa7d6cecd9eb40b2da"
+  integrity sha512-15irv0WpqSS/Y7M6IusQtPTm5Fk9dW/ibPdUJdz5pBiytDhQOukckFtMwG78Sk5u9ujcwRXBEO9gCRAd2PUNmA==
   dependencies:
     "@csstools/normalize.css" "12.0.0"
-    "@liskhq/lisk-api-client" "^6.0.0"
-    "@liskhq/lisk-client" "^6.0.0"
+    "@liskhq/lisk-api-client" "^6.0.1"
+    "@liskhq/lisk-client" "^6.0.1"
     "@liskhq/lisk-cryptography" "^4.0.0"
     "@liskhq/lisk-transactions" "^6.0.0"
     "@liskhq/lisk-utils" "^0.4.0"
     "@liskhq/lisk-validator" "^0.8.0"
     axios "1.2.0"
     express "4.18.2"
-    lisk-sdk "^6.0.0"
+    lisk-sdk "^6.0.1"
     react "^17.0.1"
     react-dom "^17.0.1"
     react-router-dom "^5.2.0"
 
-"@liskhq/lisk-framework-forger-plugin@0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@liskhq/lisk-framework-forger-plugin/-/lisk-framework-forger-plugin-0.4.0.tgz#c2c8a54cca930683bb3cf710a11e8a4cdccd92a4"
-  integrity sha512-MYTNIGfPtXRxnol3A37SEyoBkjRcDFYfPTccqGD7nokE5iWIhRu4biZ2UA5MrzVKZxkn+YMcetyAr2JXwzaUpQ==
+"@liskhq/lisk-framework-forger-plugin@0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@liskhq/lisk-framework-forger-plugin/-/lisk-framework-forger-plugin-0.4.1.tgz#7211bbce13748b46d1e2e523801995abb6fb0816"
+  integrity sha512-LLizssVqhEs3RyGxJmqLotjLvPPMxFp0vXen8s2PAgJbpAePlbEU4mkQcZg3mF9OyPhSdvSrz5LHyfG4UT0duw==
   dependencies:
     debug "4.3.4"
     fs-extra "11.1.0"
-    lisk-sdk "^6.0.0"
+    lisk-sdk "^6.0.1"
 
-"@liskhq/lisk-framework-monitor-plugin@0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@liskhq/lisk-framework-monitor-plugin/-/lisk-framework-monitor-plugin-0.4.0.tgz#072050f69400f1e2e4c02bdc51d82307682180bf"
-  integrity sha512-Q+hKaZHCMu8mOqvGH+yeQGtw/NnrDzw9Iq68zG7x7tC2fr4ZD5eZKH2TsWhiD6FxhEE7sGmzOXsPEKj6VUyFEQ==
+"@liskhq/lisk-framework-monitor-plugin@0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@liskhq/lisk-framework-monitor-plugin/-/lisk-framework-monitor-plugin-0.4.1.tgz#cf9f6512ad0eb5493808c1c3c2819cccd6a4c1d7"
+  integrity sha512-Nm4V064WZwBIAi29YOlk2YUxStZ5m8xse/RWLXEBIZKjBfxlMK/2aDG6KN4M7HXKgjmfM6LJiBGUGigNJJp69w==
   dependencies:
     cors "2.8.5"
     express "4.18.2"
     express-rate-limit "6.7.0"
     ip "1.1.5"
-    lisk-sdk "^6.0.0"
+    lisk-sdk "^6.0.1"
 
-"@liskhq/lisk-framework-report-misbehavior-plugin@0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@liskhq/lisk-framework-report-misbehavior-plugin/-/lisk-framework-report-misbehavior-plugin-0.4.0.tgz#02a8893dc01c41849eda51e40fefb8adb96a459d"
-  integrity sha512-6H/9IwSI++XAX1PpxB+NqvaPtDawea1OWS2oBkIECa5NcGo90EmIfOcnh5KSwWp6H0vTMtweG6vYOBgDsms4CQ==
+"@liskhq/lisk-framework-report-misbehavior-plugin@0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@liskhq/lisk-framework-report-misbehavior-plugin/-/lisk-framework-report-misbehavior-plugin-0.4.1.tgz#956ca9fc60892a3faa057ea87581db3e10aeb32d"
+  integrity sha512-aJsJQhtoF1k8Zx+2j2d6rpEZ0OZHNb1oOAAsRiPJYCeCwpdeLd/fRiYRTTi+PSCHwVulsPoVdem/UQRA8c+rQw==
   dependencies:
     "@liskhq/lisk-cryptography" "^4.0.0"
     fs-extra "11.1.0"
-    lisk-sdk "^6.0.0"
+    lisk-sdk "^6.0.1"
 
 "@liskhq/lisk-p2p@^0.9.0":
   version "0.9.0"
@@ -1431,9 +1431,9 @@
   integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
 
 "@types/babel__core@^7.1.14":
-  version "7.20.4"
-  resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.20.4.tgz#26a87347e6c6f753b3668398e34496d6d9ac6ac0"
-  integrity sha512-mLnSC22IC4vcWiuObSRjrLd9XcBTGf59vUSoq2jkQDJ/QQ8PMI9rSuzE+aEV8karUMbskw07bKYoUJCKTUaygg==
+  version "7.20.5"
+  resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.20.5.tgz#3df15f27ba85319caa07ba08d0721889bb39c017"
+  integrity sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==
   dependencies:
     "@babel/parser" "^7.20.7"
     "@babel/types" "^7.20.7"
@@ -1517,9 +1517,9 @@
     "@types/jest" "*"
 
 "@types/jest@*":
-  version "29.5.8"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.5.8.tgz#ed5c256fe2bc7c38b1915ee5ef1ff24a3427e120"
-  integrity sha512-fXEFTxMV2Co8ZF5aYFJv+YeA08RTYJfhtN5c9JSv/mFEMe+xxjufCb+PHL+bJcMs/ebPUsBu+UNTEz+ydXrR6g==
+  version "29.5.10"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.5.10.tgz#a10fc5bab9e426081c12b2ef73d24d4f0c9b7f50"
+  integrity sha512-tE4yxKEphEyxj9s4inideLHktW/x6DwesIwWZ9NN1FKf9zbJYsnhBoA9vrHA/IuIOKwPa5PcFBNV4lpMIOEzyQ==
   dependencies:
     expect "^29.0.0"
     pretty-format "^29.0.0"
@@ -1553,9 +1553,9 @@
   integrity sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==
 
 "@types/node@*":
-  version "20.9.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.9.0.tgz#bfcdc230583aeb891cf51e73cfdaacdd8deae298"
-  integrity sha512-nekiGu2NDb1BcVofVcEKMIwzlx4NjHlcjhoxxKBNLtz15Y1z7MYf549DFvkHSId02Ax6kGwWntIBPC3l/JZcmw==
+  version "20.10.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.10.0.tgz#16ddf9c0a72b832ec4fcce35b8249cf149214617"
+  integrity sha512-D0WfRmU9TQ8I9PFx9Yc+EBHw+vSpIub4IDvQivcp26PtPrdMGAq5SDcpXEo/epqa/DXotVpekHiLNTg3iaKXBQ==
   dependencies:
     undici-types "~5.26.4"
 
@@ -1575,9 +1575,9 @@
   integrity sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A==
 
 "@types/node@^16 || ^18":
-  version "18.18.9"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.18.9.tgz#5527ea1832db3bba8eb8023ce8497b7d3f299592"
-  integrity sha512-0f5klcuImLnG4Qreu9hPj/rEfFq6YRc5n2mAjSsH+ec/mJL+3voBH0+8T7o8RpFjH7ovc+TRsL/c7OYIQsPTfQ==
+  version "18.18.13"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.18.13.tgz#ae0f76c0bfe79d8fad0f910b78ae3e59b333c6e8"
+  integrity sha512-vXYZGRrSCreZmq1rEjMRLXJhiy8MrIeVasx+PCVlP414N7CJLHnMf+juVvjdprHyH+XRy3zKZLHeNueOpJCn0g==
   dependencies:
     undici-types "~5.26.4"
 
@@ -1592,9 +1592,9 @@
   integrity sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==
 
 "@types/semver@^7.3.12":
-  version "7.5.5"
-  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.5.tgz#deed5ab7019756c9c90ea86139106b0346223f35"
-  integrity sha512-+d+WYC1BxJ6yVOgUgzK8gWvp5qF8ssV5r4nsDcZWKRWcDQLQ619tvWAxJQYGgBrO1MnLJC7a5GtiYsAoQ47dJg==
+  version "7.5.6"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.6.tgz#c65b2bfce1bec346582c07724e3f8c1017a20339"
+  integrity sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==
 
 "@types/stack-utils@^2.0.0":
   version "2.0.3"
@@ -1610,17 +1610,17 @@
     minipass "^3.3.5"
 
 "@types/tar@^6.1.4":
-  version "6.1.9"
-  resolved "https://registry.yarnpkg.com/@types/tar/-/tar-6.1.9.tgz#1f8f7033494224e61b97895070fafcdd6ec370f3"
-  integrity sha512-T3+O+OQd9cdGmOXuKQY9+B0ceZHRlGVPQ7M5QZqkaPyP/vWnxPXM2aCegq8GP/n1n9dBfq2EBUqCSKKjQAVOPA==
+  version "6.1.10"
+  resolved "https://registry.yarnpkg.com/@types/tar/-/tar-6.1.10.tgz#10b0e12129f4af5909af82a055837116ab06f860"
+  integrity sha512-60ZO+W0tRKJ3ggdzJKp75xKVlNogKYMqGvr2bMH/+k3T0BagfYTnbmVDFMJB1BFttz6yRgP5MDGP27eh7brrqw==
   dependencies:
     "@types/node" "*"
     minipass "^4.0.0"
 
 "@types/vinyl@^2.0.4":
-  version "2.0.10"
-  resolved "https://registry.yarnpkg.com/@types/vinyl/-/vinyl-2.0.10.tgz#0be9d0750816b945f66dc7b24a5dee8a7bda1574"
-  integrity sha512-DqN5BjCrmjAtZ1apqzcq2vk2PSW0m1nFfjIafBFkAyddmHxuw3ZAK3omLiSdpuu81+8h07i6U4DtaE38Xsf2xQ==
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/@types/vinyl/-/vinyl-2.0.11.tgz#b95a5bb007e7a0a61dad5a8971dc9922abbc2629"
+  integrity sha512-vPXzCLmRp74e9LsP8oltnWKTH+jBwt86WgRUb4Pc9Lf3pkMVGyvIo2gm9bODeGfCay2DBB/hAWDuvf07JcK4rw==
   dependencies:
     "@types/expect" "^1.20.4"
     "@types/node" "*"
@@ -1631,9 +1631,9 @@
   integrity sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==
 
 "@types/yargs@^17.0.8":
-  version "17.0.31"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.31.tgz#8fd0089803fd55d8a285895a18b88cb71a99683c"
-  integrity sha512-bocYSx4DI8TmdlvxqGpVNXOgCNR1Jj0gNPhhAY+iz1rgKDAaYrAYdFYnhDV1IFuiuVc9HkOwyDcFxaTElF3/wg==
+  version "17.0.32"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.32.tgz#030774723a2f7faafebf645f4e5a48371dca6229"
+  integrity sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==
   dependencies:
     "@types/yargs-parser" "*"
 
@@ -2512,9 +2512,9 @@ camelcase@^6.2.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001541:
-  version "1.0.30001562"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001562.tgz#9d16c5fd7e9c592c4cd5e304bc0f75b0008b2759"
-  integrity sha512-kfte3Hym//51EdX4239i+Rmp20EsLIYGdPkERegTgU19hQWCRhsRFGKHTliUlsry53tv17K7n077Kqa0WJU4ng==
+  version "1.0.30001564"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001564.tgz#eaa8bbc58c0cbccdcb7b41186df39dd2ba591889"
+  integrity sha512-DqAOf+rhof+6GVx1y+xzbFPeOumfQnhYzVnZD6LAXijR77yPtm9mfOcqOnT3mpnJiZVT+kwLAFnRlZcIz+c6bg==
 
 cardinal@^2.1.1:
   version "2.1.1"
@@ -2637,9 +2637,9 @@ cli-progress@^3.10.0, cli-progress@^3.4.0:
     string-width "^4.2.3"
 
 cli-spinners@^2.5.0:
-  version "2.9.1"
-  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.9.1.tgz#9c0b9dad69a6d47cbb4333c14319b060ed395a35"
-  integrity sha512-jHgecW0pxkonBJdrKsqxgRX9AcG+u/5k0Q7WPDfi8AogLAdwxEkyYYNWwZ5GvVFoFx2uiY1eNcSK00fh+1+FyQ==
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.9.2.tgz#1773a8f4b9c4d6ac31563df53b3fc1d79462fe41"
+  integrity sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==
 
 cli-table3@0.6.0:
   version "0.6.0"
@@ -3204,9 +3204,9 @@ ejs@^3.1.6, ejs@^3.1.8:
     jake "^10.8.5"
 
 electron-to-chromium@^1.4.535:
-  version "1.4.583"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.583.tgz#7b0ac4f36388da4b5485788adb92cd7dd0abffc4"
-  integrity sha512-93y1gcONABZ7uqYe/JWDVQP/Pj/sQSunF0HVAPdlg/pfBnOyBMLlQUxWvkqcljJg1+W6cjvPuYD+r1Th9Tn8mA==
+  version "1.4.594"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.594.tgz#f69f207fba80735a44a988df42f3f439115d0515"
+  integrity sha512-xT1HVAu5xFn7bDfkjGQi9dNpMqGchUkebwf1GL7cZN32NSwwlHRPMSDJ1KN6HkS0bWUtndbSQZqvpQftKG2uFQ==
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -4484,9 +4484,9 @@ ignore@^4.0.6:
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
 ignore@^5.1.1, ignore@^5.2.0:
-  version "5.2.4"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
-  integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.0.tgz#67418ae40d34d6999c95ff56016759c718c82f78"
+  integrity sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==
 
 import-fresh@^3.0.0, import-fresh@^3.2.1:
   version "3.3.0"
@@ -5532,14 +5532,14 @@ lint-staged@10.5.4:
     string-argv "0.3.1"
     stringify-object "^3.3.0"
 
-lisk-commander@6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/lisk-commander/-/lisk-commander-6.0.0.tgz#7acfbe8131bfcfb28ab8a5aa16ebdbd5936782ba"
-  integrity sha512-upj5kJwDxci+3RuUdGhotwMDkhcoAAzpfobyAXzBcKS5/ZkQeY4d0xI+l5wckUL0ssPB/iuMgvw4uMKb3pXmbQ==
+lisk-commander@6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/lisk-commander/-/lisk-commander-6.0.1.tgz#169eb838326fff89f2419720bcc0501218df3093"
+  integrity sha512-5R/am2s14Q0cj6km0c/Bw4sYokouzEXv/heY67Z70O1bSRgVa7mZItk0g/dMMXKYBqzL+u5lQmGEl49Mq4/mTQ==
   dependencies:
-    "@liskhq/lisk-api-client" "^6.0.0"
+    "@liskhq/lisk-api-client" "^6.0.1"
     "@liskhq/lisk-chain" "^0.5.0"
-    "@liskhq/lisk-client" "^6.0.0"
+    "@liskhq/lisk-client" "^6.0.1"
     "@liskhq/lisk-codec" "^0.4.0"
     "@liskhq/lisk-cryptography" "^4.0.0"
     "@liskhq/lisk-db" "0.3.10"
@@ -5557,7 +5557,7 @@ lisk-commander@6.0.0:
     cli-table3 "0.6.0"
     fs-extra "11.1.0"
     inquirer "8.2.5"
-    lisk-framework "^0.11.0"
+    lisk-framework "^0.11.1"
     listr "0.14.3"
     progress "2.0.3"
     semver "7.5.2"
@@ -5568,13 +5568,13 @@ lisk-commander@6.0.0:
     yeoman-environment "3.12.1"
     yeoman-generator "5.7.0"
 
-lisk-framework@^0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/lisk-framework/-/lisk-framework-0.11.0.tgz#ca1ba9f781902dd5ab9442d91d74f60bd600d0c8"
-  integrity sha512-28kKCM0O04EPubXqXTf6S0FDE/sFCd1QB8LCfpj+ZeZFPO3E2rX9iCOJE7wR/IqgyrVJA0SyY8o1yAoZ52HGEA==
+lisk-framework@^0.11.1:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/lisk-framework/-/lisk-framework-0.11.1.tgz#4de5408c14718f577c5fd0514eef33604667f3c5"
+  integrity sha512-koO2zw2siIwk41auYht+1faeqViGRRcmjbOJ4lMPad11zQVjRDCxoXCNfKmG6L0mdQ+1HtEAX3gjvR/djaNrxw==
   dependencies:
     "@chainsafe/blst" "0.2.9"
-    "@liskhq/lisk-api-client" "^6.0.0"
+    "@liskhq/lisk-api-client" "^6.0.1"
     "@liskhq/lisk-chain" "^0.5.0"
     "@liskhq/lisk-codec" "^0.4.0"
     "@liskhq/lisk-cryptography" "^4.0.0"
@@ -5595,12 +5595,12 @@ lisk-framework@^0.11.0:
     ws "8.11.0"
     zeromq "6.0.0-beta.6"
 
-lisk-sdk@6.0.0, lisk-sdk@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/lisk-sdk/-/lisk-sdk-6.0.0.tgz#2359839fc6689b13be3df1d72c176983dbed0518"
-  integrity sha512-78/XacYljN0t4CUD+it58GJIMaFJu+Q2TQ8RMD8+MvobkIxbyxXtSOX+/GOToCEeL5UXPHZycVY3HKJIbFRgAQ==
+lisk-sdk@6.0.1, lisk-sdk@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/lisk-sdk/-/lisk-sdk-6.0.1.tgz#a021eda9e17b6e55fcfe5fa15fb06f335400ee79"
+  integrity sha512-qU+ek8RPKIgJVx8bGiOgjKXbgSeD9dlfGKJMTn8W/XhvWgQLH7E23gdYafwScJcGBDD7AW1BwAQwVDTLA0xJDg==
   dependencies:
-    "@liskhq/lisk-api-client" "^6.0.0"
+    "@liskhq/lisk-api-client" "^6.0.1"
     "@liskhq/lisk-chain" "^0.5.0"
     "@liskhq/lisk-codec" "^0.4.0"
     "@liskhq/lisk-cryptography" "^4.0.0"
@@ -5612,7 +5612,7 @@ lisk-sdk@6.0.0, lisk-sdk@^6.0.0:
     "@liskhq/lisk-tree" "^0.4.0"
     "@liskhq/lisk-utils" "^0.4.0"
     "@liskhq/lisk-validator" "^0.8.0"
-    lisk-framework "^0.11.0"
+    lisk-framework "^0.11.1"
 
 listr-silent-renderer@^1.1.1:
   version "1.1.1"
@@ -6237,9 +6237,9 @@ node-fetch@^2.6.1, node-fetch@^2.6.7:
     whatwg-url "^5.0.0"
 
 node-gyp-build@^4.1.0, node-gyp-build@^4.2.0:
-  version "4.6.1"
-  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.6.1.tgz#24b6d075e5e391b8d5539d98c7fc5c210cac8a3e"
-  integrity sha512-24vnklJmyRS8ViBNI8KbtK/r/DmXQMRiOMXTNz2nrTnAYUwjmEEbnnpB/+kt+yWRv73bPsSPRFddrcIbAxSiMQ==
+  version "4.7.1"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.7.1.tgz#cd7d2eb48e594874053150a9418ac85af83ca8f7"
+  integrity sha512-wTSrZ+8lsRRa3I3H8Xr65dLWSgCvY2l4AOnaeKdPA9TB/WYMPaTcrzf3rXvFoVvjKNVnu0CcWSx54qq9GKRUYg==
 
 node-gyp@^8.2.0, node-gyp@^8.4.0:
   version "8.4.1"
@@ -8359,9 +8359,9 @@ v8-compile-cache@^2.0.3:
   integrity sha512-ocyWc3bAHBB/guyqJQVI5o4BZkPhznPYUG2ea80Gond/BgNWpap8TOmLSeeQG7bnh2KMISxskdADG59j7zruhw==
 
 v8-to-istanbul@^9.0.1:
-  version "9.1.3"
-  resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-9.1.3.tgz#ea456604101cd18005ac2cae3cdd1aa058a6306b"
-  integrity sha512-9lDD+EVI2fjFsMWXc6dy5JJzBsVTcQ2fVkfBvncZ6xJWG9wtBhOldG+mHkSL0+V1K/xgZz0JDO5UT5hFwHUghg==
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-9.2.0.tgz#2ed7644a245cddd83d4e087b9b33b3e62dfd10ad"
+  integrity sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==
   dependencies:
     "@jridgewell/trace-mapping" "^0.3.12"
     "@types/istanbul-lib-coverage" "^2.0.1"


### PR DESCRIPTION
### What was the problem?

This PR resolves #896 

### How was it solved?

- [x] Updated Lisk SDK to v6.0.1
- [x] Lisk Core version already bumped and docs are up-to-date

### How was it tested?

- make build
  - `./bin/run start -n testnet`
  - `docker run --name lisk-core lisk/core start --network=testnet --log=debug`
